### PR TITLE
integrate rampify and smooth terrain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "heightmap"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "brdb",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heightmap"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Isaac <gpg@reheatedcake.io>"]
 edition = "2024"
 rust-version = "1.88"

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ family (ramp, wedge corner, inner corner, or a stacked outer corner plus
 triangle) that best matches its four corner heights. Neighbouring cells quote
 the same vertices, so their surfaces meet rather than step. Every candidate is
 fitted *from below*, so no cell can protrude through its neighbour and a clean
-cliff comes out as one exact steep ramp instead of a shelf. Costs roughly 1.5
-to 2.5 bricks per pixel. Under `--terrain`, `--vertical` is the height of one
+cliff comes out as one exact steep ramp instead of a shelf. Foundations are a
+flat-topped field, so they are greedy-merged into boxes rather than left one per
+pixel. Costs roughly 0.7 to 2.5 bricks per pixel, depending on how much of the
+map is flat and uniformly coloured. Under `--terrain`, `--vertical` is the height of one
 shade of grey in units, rounded up to an even number (a wedge's half height has
 to be a whole unit).
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ FLAGS:
         --lrgb         Use linear rgb input color instead of sRGB
         --micro        Render bricks as micro bricks
         --nocollide    Disable brick collision
+        --prefab       Write a prefab bundle instead of a world
+        --rampify      Rampify the terrain with Wrapperup's rampifier
         --smooth       Render bricks as smooth tiles
         --snap         Snap bricks to the brick grid
         --stud         Render bricks as stud cubes
+        --terrain      Render the terrain as smooth micro bricks
         --text         Render the input image as TextDisplay component bricks
         --tile         Render bricks as tiles
     -V, --version      Prints version information
@@ -56,6 +59,45 @@ OPTIONS:
 ARGS:
     <INPUT>...    Input heightmap image files (PNG/JPG)
 ```
+
+### Smooth surfaces
+
+By default every pixel becomes a flat-topped prism, so a slope renders as a
+staircase. Two flags replace that with a sloped surface. They are alternatives
+to each other and to `--tile`/`--smooth`/`--micro`/`--stud`, and they choose
+their own bricks per cell, so the optimizer flags (`--greedy`, `--snap`) do not
+apply to them.
+
+`--terrain` builds the surface out of **micro wedges**. Heights are sampled on a
+shared `(w+1) x (h+1)` vertex grid — each vertex is the mean of the pixels
+touching it — and every cell picks the assembly from Brickadia's micro wedge
+family (ramp, wedge corner, inner corner, or a stacked outer corner plus
+triangle) that best matches its four corner heights. Neighbouring cells quote
+the same vertices, so their surfaces meet rather than step. Every candidate is
+fitted *from below*, so no cell can protrude through its neighbour and a clean
+cliff comes out as one exact steep ramp instead of a shelf. Costs roughly 1.5
+to 2.5 bricks per pixel. Under `--terrain`, `--vertical` is the height of one
+shade of grey in units, rounded up to an even number (a wedge's half height has
+to be a whole unit).
+
+`heightmap heightmap.png -c colormap.png --terrain -v 4 -o terrain.brz`
+
+`--rampify` runs [Wrapperup's rampifier](https://github.com/Wrapperup/rampifier)
+over the height columns instead: it fits full-size `PB_DefaultRamp`,
+`PB_DefaultWedge` and ramp corner pieces onto the surface and fills the rest
+with plain bricks. Coarser than `--terrain` — one plate of vertical resolution,
+runs of at most 4 studs — but it builds from ordinary bricks rather than micro
+pieces, and flat ground merges into large blocks. Under `--rampify`,
+`--vertical` is rounded to a whole number of plates (4 units).
+
+`heightmap heightmap.png -c colormap.png --rampify -v 8 -o rampified.brz`
+
+Add `--prefab` to either (or to any heightmap/`--img` render) to write a prefab
+bundle instead of a world, so the save can be dropped into Brickadia's `Prefabs`
+folder and spawned from the prefab browser.
+
+In the GUI both appear in the **Brick Type** row as *Smooth Terrain* and
+*Rampify*.
 
 ###  Examples
 

--- a/src/gui/heightmap.rs
+++ b/src/gui/heightmap.rs
@@ -69,6 +69,9 @@ enum PickTarget {
     Colormap,
 }
 
+/// What the Brick Type row picks. The first five choose which asset the blocky
+/// renderer stacks; the last two replace the renderer, because a sloped surface
+/// is not built out of one repeated brick.
 #[derive(PartialEq, Clone)]
 enum BrickMode {
     Default,
@@ -76,6 +79,20 @@ enum BrickMode {
     SmoothTile,
     Stud,
     Micro,
+    /// Smooth micro-wedge terrain (`opt::terrain`).
+    Terrain,
+    /// Wrapperup's rampifier over the height columns (`opt::rampify`).
+    Rampify,
+}
+
+impl BrickMode {
+    fn surface(&self) -> SurfaceMode {
+        match self {
+            BrickMode::Terrain => SurfaceMode::Terrain,
+            BrickMode::Rampify => SurfaceMode::Rampify,
+            _ => SurfaceMode::Blocks,
+        }
+    }
 }
 
 #[derive(PartialEq, Clone)]
@@ -167,7 +184,18 @@ impl HeightmapApp {
     }
 
     fn options(&self, img_only: bool) -> GenOptions {
+        let img = img_only || (self.heightmaps.is_empty() && self.colormap.is_some());
+        // The sloped renderers only exist for a heightmap; a flat image has no
+        // terrain to slope, so the Image2Brick pane falls back to blocks rather
+        // than paving an unchanging plane in wedges.
+        let surface = if img {
+            SurfaceMode::Blocks
+        } else {
+            self.mode.surface()
+        };
         GenOptions {
+            // `--size` counts STUDS everywhere except the blocky micro mode,
+            // which reinterprets it as micro units.
             size: if self.mode == BrickMode::Micro {
                 self.horizontal_size
             } else {
@@ -181,17 +209,21 @@ impl HeightmapApp {
                 BrickMode::SmoothTile => PB_DEFAULT_SMOOTH_TILE,
                 BrickMode::Stud => PB_DEFAULT_STUDDED,
                 BrickMode::Micro => PB_DEFAULT_MICRO_BRICK,
+                // Both sloped renderers choose their own assets per cell and
+                // never read this one.
+                BrickMode::Terrain | BrickMode::Rampify => PB_DEFAULT_MICRO_BRICK,
             },
             micro: self.mode == BrickMode::Micro,
             stud: self.mode == BrickMode::Stud,
             snap: self.opt_snap,
-            img: img_only || (self.heightmaps.is_empty() && self.colormap.is_some()),
+            img,
             glow: self.opt_glow,
             hdmap: self.opt_hdmap,
             lrgb: self.opt_lrgb,
             nocollide: self.opt_nocollide,
             quadtree: self.optimization == OptimizationMode::Quad,
             greedy: self.optimization == OptimizationMode::Greedy,
+            surface,
         }
     }
 
@@ -372,7 +404,28 @@ impl HeightmapApp {
                         .on_hover_text("Use studded bricks");
                     widgets::radio(ui, &mut self.mode, BrickMode::Micro, "Micro")
                         .on_hover_text("Use micro bricks");
+                    widgets::radio(ui, &mut self.mode, BrickMode::Terrain, "Smooth Terrain")
+                        .on_hover_text(
+                            "Build a SMOOTH surface out of micro wedges instead of flat-topped tiles: \n\
+                             every pixel gets a sloped top fitted to the heights of the four shared \n\
+                             grid vertices around it, so neighbouring cells meet instead of stepping.\n\
+                             Uses roughly 1.5 to 2.5 bricks per pixel",
+                        );
+                    widgets::radio(ui, &mut self.mode, BrickMode::Rampify, "Rampify")
+                        .on_hover_text(
+                            "Smooth the surface with Wrapperup's rampifier: fit full-size ramps, \n\
+                             wedges and ramp corners onto the height columns and fill the rest with \n\
+                             plain bricks. Coarser than Smooth Terrain (one plate of vertical \n\
+                             resolution) but builds from ordinary bricks",
+                        );
                 });
+                if self.mode.surface() != SurfaceMode::Blocks {
+                    ui.colored_label(
+                        Color32::from_rgb(255, 200, 100),
+                        "Note: this mode picks its own bricks per cell, so the Optimization and \
+                         Snap settings above do not apply",
+                    );
+                }
             });
         });
     }

--- a/src/gui/heightmap.rs
+++ b/src/gui/heightmap.rs
@@ -350,26 +350,31 @@ impl HeightmapApp {
             }
 
             t.row_hover(ui, "Optimization", Some("Algorithm used to reduce brick count"), |ui| {
-                ui.horizontal_wrapped(|ui| {
-                    widgets::radio(ui, &mut self.optimization, OptimizationMode::None, "None")
-                        .on_hover_text("No optimization (~one brick per pixel)");
-                    widgets::radio(ui, &mut self.optimization, OptimizationMode::Quad, "Quadtree")
-                        .on_hover_text("Use quadtree based optimization. Looks prettier. May use more bricks. Uses a lot of memory for larger maps");
-                    widgets::radio(ui, &mut self.optimization, OptimizationMode::Greedy, "Greedy")
-                        .on_hover_text("Use greedy mesh for each height level. Uses fewer bricks but slower for images with many colors/heights");
+                // Vertical for the same reason as the Brick Type row below: the
+                // control column is horizontal, so these two notes went to the
+                // RIGHT of the buttons and each wrapped into a narrow column.
+                ui.vertical(|ui| {
+                    ui.horizontal_wrapped(|ui| {
+                        widgets::radio(ui, &mut self.optimization, OptimizationMode::None, "None")
+                            .on_hover_text("No optimization (~one brick per pixel)");
+                        widgets::radio(ui, &mut self.optimization, OptimizationMode::Quad, "Quadtree")
+                            .on_hover_text("Use quadtree based optimization. Looks prettier. May use more bricks. Uses a lot of memory for larger maps");
+                        widgets::radio(ui, &mut self.optimization, OptimizationMode::Greedy, "Greedy")
+                            .on_hover_text("Use greedy mesh for each height level. Uses fewer bricks but slower for images with many colors/heights");
+                    });
+                    if self.optimization == OptimizationMode::Greedy && !self.heightmaps.is_empty() {
+                        ui.colored_label(
+                            Color32::from_rgb(255, 200, 100),
+                            "Note: Greedy meshing does not properly calculate brick heights based on neighbor heights",
+                        );
+                    }
+                    if self.optimization == OptimizationMode::Greedy && self.has_large_image() {
+                        ui.colored_label(
+                            Color32::from_rgb(255, 100, 100),
+                            "Warning: Large images (>1024px) may use excessive memory with greedy optimization",
+                        );
+                    }
                 });
-                if self.optimization == OptimizationMode::Greedy && !self.heightmaps.is_empty() {
-                    ui.colored_label(
-                        Color32::from_rgb(255, 200, 100),
-                        "Note: Greedy meshing does not properly calculate brick heights based on neighbor heights",
-                    );
-                }
-                if self.optimization == OptimizationMode::Greedy && self.has_large_image() {
-                    ui.colored_label(
-                        Color32::from_rgb(255, 100, 100),
-                        "Warning: Large images (>1024px) may use excessive memory with greedy optimization",
-                    );
-                }
             });
 
             t.row_hover(ui, "Options", Some("A list of options for modifying how the generator works"), |ui| {
@@ -394,39 +399,47 @@ impl HeightmapApp {
             });
 
             t.row_hover(ui, "Brick Type", Some("Change which brick type is used for the save file"), |ui| {
-                ui.horizontal_wrapped(|ui| {
-                    widgets::radio(ui, &mut self.mode, BrickMode::Default, "Default")
-                        .on_hover_text("Use default bricks");
-                    widgets::radio(ui, &mut self.mode, BrickMode::Tile, "Tile")
-                        .on_hover_text("Use tile bricks");
-                    widgets::radio(ui, &mut self.mode, BrickMode::SmoothTile, "Smooth")
-                        .on_hover_text("Use smooth tile bricks");
-                    widgets::radio(ui, &mut self.mode, BrickMode::Stud, "Stud")
-                        .on_hover_text("Use studded bricks");
-                    widgets::radio(ui, &mut self.mode, BrickMode::Micro, "Micro")
-                        .on_hover_text("Use micro bricks");
-                    widgets::radio(ui, &mut self.mode, BrickMode::Terrain, "Smooth Terrain")
-                        .on_hover_text(
-                            "Build a SMOOTH surface out of micro wedges instead of flat-topped tiles: \n\
-                             every pixel gets a sloped top fitted to the heights of the four shared \n\
-                             grid vertices around it, so neighbouring cells meet instead of stepping.\n\
-                             Uses roughly 1.5 to 2.5 bricks per pixel",
+                // `row_hover` gives the control a HORIZONTAL layout, so a note
+                // after the buttons becomes the next item in that flow and goes
+                // to the RIGHT of them. The space that stays is a few
+                // characters wide, and the note then wraps into a tall, narrow
+                // column. This vertical layout puts the note below the buttons,
+                // where it gets the full width of the control column.
+                ui.vertical(|ui| {
+                    ui.horizontal_wrapped(|ui| {
+                        widgets::radio(ui, &mut self.mode, BrickMode::Default, "Default")
+                            .on_hover_text("Use default bricks");
+                        widgets::radio(ui, &mut self.mode, BrickMode::Tile, "Tile")
+                            .on_hover_text("Use tile bricks");
+                        widgets::radio(ui, &mut self.mode, BrickMode::SmoothTile, "Smooth")
+                            .on_hover_text("Use smooth tile bricks");
+                        widgets::radio(ui, &mut self.mode, BrickMode::Stud, "Stud")
+                            .on_hover_text("Use studded bricks");
+                        widgets::radio(ui, &mut self.mode, BrickMode::Micro, "Micro")
+                            .on_hover_text("Use micro bricks");
+                        widgets::radio(ui, &mut self.mode, BrickMode::Terrain, "Smooth Terrain")
+                            .on_hover_text(
+                                "Build a SMOOTH surface out of micro wedges instead of flat-topped tiles: \n\
+                                 every pixel gets a sloped top fitted to the heights of the four shared \n\
+                                 grid vertices around it, so neighbouring cells meet instead of stepping.\n\
+                                 Uses roughly 1.5 to 2.5 bricks per pixel",
+                            );
+                        widgets::radio(ui, &mut self.mode, BrickMode::Rampify, "Rampify")
+                            .on_hover_text(
+                                "Smooth the surface with Wrapperup's rampifier: fit full-size ramps, \n\
+                                 wedges and ramp corners onto the height columns and fill the rest with \n\
+                                 plain bricks. Coarser than Smooth Terrain (one plate of vertical \n\
+                                 resolution) but builds from ordinary bricks",
+                            );
+                    });
+                    if self.mode.surface() != SurfaceMode::Blocks {
+                        ui.colored_label(
+                            Color32::from_rgb(255, 200, 100),
+                            "Note: this mode picks its own bricks per cell, so the Optimization and \
+                             Snap settings above do not apply",
                         );
-                    widgets::radio(ui, &mut self.mode, BrickMode::Rampify, "Rampify")
-                        .on_hover_text(
-                            "Smooth the surface with Wrapperup's rampifier: fit full-size ramps, \n\
-                             wedges and ramp corners onto the height columns and fill the rest with \n\
-                             plain bricks. Coarser than Smooth Terrain (one plate of vertical \n\
-                             resolution) but builds from ordinary bricks",
-                        );
+                    }
                 });
-                if self.mode.surface() != SurfaceMode::Blocks {
-                    ui.colored_label(
-                        Color32::from_rgb(255, 200, 100),
-                        "Note: this mode picks its own bricks per cell, so the Optimization and \
-                         Snap settings above do not apply",
-                    );
-                }
             });
         });
     }
@@ -675,6 +688,93 @@ mod tests {
             finish(Err(halt)),
             Err("failed to write file".to_string()),
             "a converted error must still be reported to the user"
+        );
+    }
+
+    /// The Brick Type and Optimization notes must sit BELOW their buttons, at
+    /// the full width of the control column.
+    ///
+    /// `SettingsTable::row_hover` gives the control a HORIZONTAL layout. A note
+    /// added after the buttons is thus the next item in that flow and goes to
+    /// the RIGHT of them, in the few characters of space that stay. It then
+    /// wraps into a tall, narrow column. The correction is one `ui.vertical`
+    /// around each control body, which no type or compile check can hold, and
+    /// which a person could remove during a tidy of the code.
+    ///
+    /// The test drives a real `egui::Context` and reads the text that the pane
+    /// paints. egui needs no window for this.
+    #[test]
+    fn a_mode_note_is_painted_below_the_buttons_and_not_beside_them() {
+        const NOTE: &str = "Note: this mode picks its own bricks per cell, so the Optimization \
+                            and Snap settings above do not apply";
+
+        let ctx = Context::default();
+        crate::gui::theme::install(&ctx);
+        let mut app = HeightmapApp::default();
+        app.mode = BrickMode::Terrain;
+        let mut shared = SharedOptions::default();
+
+        let mut texts: Vec<(egui::Rect, String)> = Vec::new();
+        // Four frames to settle: a table learns its column widths from the
+        // frame before, so the first frame is not representative.
+        for _ in 0..4 {
+            let input = egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::pos2(0.0, 0.0),
+                    egui::vec2(900.0, 2400.0),
+                )),
+                ..Default::default()
+            };
+            let out = ctx.run(input, |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    app.draw_settings(ui, &mut shared, false);
+                });
+            });
+            texts = out
+                .shapes
+                .iter()
+                .filter_map(|c| match &c.shape {
+                    egui::epaint::Shape::Text(t) => Some((
+                        egui::Rect::from_min_size(t.pos, t.galley.rect.size()),
+                        t.galley.text().to_string(),
+                    )),
+                    _ => None,
+                })
+                .collect();
+        }
+
+        let rect = |want: &str| {
+            texts
+                .iter()
+                .find(|(_, s)| s == want)
+                .map(|(r, _)| *r)
+                .unwrap_or_else(|| panic!("the pane painted no text {want:?}"))
+        };
+        let note = rect(NOTE);
+        let rampify = rect("Rampify");
+
+        assert!(
+            note.top() >= rampify.bottom(),
+            "the note is beside the buttons: the note is at y {}..{} and the last button is at \
+             y {}..{}",
+            note.top(),
+            note.bottom(),
+            rampify.top(),
+            rampify.bottom(),
+        );
+        assert!(
+            note.left() <= rampify.left() + 1.0,
+            "the note starts at x {} but the buttons start at x {}, so it is in a column to \
+             their right",
+            note.left(),
+            rampify.left(),
+        );
+        // The narrow column is what looks incorrect, so measure it: a note that
+        // gets the width of the control column is wide and short.
+        assert!(
+            note.width() > 300.0,
+            "the note is {} wide in a pane of 900, so it still wraps too much",
+            note.width(),
         );
     }
 }

--- a/src/gui/heightmap.rs
+++ b/src/gui/heightmap.rs
@@ -69,9 +69,10 @@ enum PickTarget {
     Colormap,
 }
 
-/// What the Brick Type row picks. The first five choose which asset the blocky
-/// renderer stacks; the last two replace the renderer, because a sloped surface
-/// is not built out of one repeated brick.
+/// What the Brick Type row selects. The first five values select the asset
+/// that the usual renderer puts above itself. The last two values replace the
+/// renderer, because one brick used again and again cannot make a sloped
+/// surface.
 #[derive(PartialEq, Clone)]
 enum BrickMode {
     Default,
@@ -79,9 +80,9 @@ enum BrickMode {
     SmoothTile,
     Stud,
     Micro,
-    /// Smooth micro-wedge terrain (`opt::terrain`).
+    /// Smooth micro wedge terrain (`opt::terrain`).
     Terrain,
-    /// Wrapperup's rampifier over the height columns (`opt::rampify`).
+    /// The Wrapperup rampifier over the height columns (`opt::rampify`).
     Rampify,
 }
 
@@ -185,17 +186,17 @@ impl HeightmapApp {
 
     fn options(&self, img_only: bool) -> GenOptions {
         let img = img_only || (self.heightmaps.is_empty() && self.colormap.is_some());
-        // The sloped renderers only exist for a heightmap; a flat image has no
-        // terrain to slope, so the Image2Brick pane falls back to blocks rather
-        // than paving an unchanging plane in wedges.
+        // The sloped renderers are for a heightmap only. A flat image has no
+        // ground to slope, so the Image2Brick page uses blocks. If it did not,
+        // it would fill a level plane with wedges.
         let surface = if img {
             SurfaceMode::Blocks
         } else {
             self.mode.surface()
         };
         GenOptions {
-            // `--size` counts STUDS everywhere except the blocky micro mode,
-            // which reinterprets it as micro units.
+            // `--size` counts STUDS in each mode, but the micro mode counts
+            // micro units.
             size: if self.mode == BrickMode::Micro {
                 self.horizontal_size
             } else {
@@ -209,8 +210,8 @@ impl HeightmapApp {
                 BrickMode::SmoothTile => PB_DEFAULT_SMOOTH_TILE,
                 BrickMode::Stud => PB_DEFAULT_STUDDED,
                 BrickMode::Micro => PB_DEFAULT_MICRO_BRICK,
-                // Both sloped renderers choose their own assets per cell and
-                // never read this one.
+                // The two sloped renderers select their own asset for each
+                // cell. They never read this value.
                 BrickMode::Terrain | BrickMode::Rampify => PB_DEFAULT_MICRO_BRICK,
             },
             micro: self.mode == BrickMode::Micro,

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,9 @@ fn cli() -> clap::App<'static, 'static> {
         (@arg smooth: --smooth "Render bricks as smooth tiles")
         (@arg micro: --micro "Render bricks as micro bricks")
         (@arg stud: --stud "Render bricks as stud cubes")
+        (@arg terrain: --terrain "Render the terrain as SMOOTH micro bricks instead of flat-topped tiles: every pixel gets a sloped top chosen from Brickadia's micro wedge family (ramp, wedge corner, inner corner, and the stacked diagonal corner+triangle), fitted to the four shared vertex heights around it. Heights are sampled on a shared (w+1)x(h+1) vertex grid so neighbouring cells MEET rather than step. Replaces --tile/--smooth/--micro/--stud and the optimizers, which have no meaning once the top face is not flat")
+        (@arg rampify: --rampify "Rampify the terrain with Wrapperup's rampifier: fit full-size ramps, wedges and ramp corners onto the height column surface and fill the rest with plain bricks. Coarser than --terrain (one plate of vertical resolution, runs of at most 4 studs) but uses ordinary bricks rather than micro pieces. Replaces --tile/--smooth/--micro/--stud and the optimizers")
+        (@arg prefab: --prefab "Heightmap/image renders: write a PREFAB bundle instead of a world, so the save can be dropped in Brickadia's Prefabs folder and spawned from the prefab browser rather than loaded as a level")
         (@arg snap: --snap "Snap bricks to the brick grid")
         (@arg lrgb: --lrgb "Use linear rgb input color instead of sRGB")
         (@arg img: -i --img "Make the heightmap flat and render an image")
@@ -311,6 +314,24 @@ fn main() {
             "--anim-mode takes precedence over --text; this render is the ANIMATED wired \
              build, not the static text export. Pass one output mode"
         );
+    }
+
+    // The heightmap-only flags, named out loud when another renderer has
+    // already won the dispatch below. Same policy as `--subtitles` above: a
+    // user who passed `--terrain --text` and got a glyph export would
+    // reasonably conclude the terrain renderer was broken.
+    if ["midi", "audiomode", "animmode", "text"]
+        .iter()
+        .any(|m| matches.is_present(m))
+    {
+        for flag in ["terrain", "rampify", "prefab"] {
+            if matches.is_present(flag) {
+                warn!(
+                    "--{flag} applies to heightmap and --img renders only; this render is \
+                     built by another mode and ignores it"
+                );
+            }
+        }
     }
 
     if matches.is_present("midi") {
@@ -1412,9 +1433,56 @@ fn run_heightmap(
         Err(e) => fail(e),
     };
 
+    // The two sloped surface renderers. Refused together rather than silently
+    // preferring one: they are different techniques with different brick
+    // families, and a user who passed both has one of them in mind.
+    let surface = match (matches.is_present("terrain"), matches.is_present("rampify")) {
+        (true, true) => fail!(
+            "--terrain and --rampify are two different smoothing techniques and cannot be \
+             combined: --terrain fits micro wedges to a shared vertex grid, --rampify fits \
+             full-size ramps to the height columns. Pass exactly one"
+        ),
+        (true, false) => SurfaceMode::Terrain,
+        (false, true) => SurfaceMode::Rampify,
+        (false, false) => SurfaceMode::Blocks,
+    };
+    // Every flag below shapes a FLAT-TOPPED prism, which is the one thing a
+    // sloped renderer does not build. Named out loud one at a time rather than
+    // dropped, the same way the audio branch names the flags it cannot honour:
+    // a render that silently ignored `--greedy` would look like it worked.
+    if surface != SurfaceMode::Blocks {
+        let mode = if surface == SurfaceMode::Terrain { "--terrain" } else { "--rampify" };
+        for (flag, name) in [
+            ("--tile", "tile"),
+            ("--smooth", "smooth"),
+            ("--stud", "stud"),
+            ("--greedy", "greedy"),
+            ("--snap", "snap"),
+        ] {
+            if matches.is_present(name) {
+                warn!(
+                    "{mode} ignores {flag}: it picks its own bricks from a shape grammar rather \
+                     than stacking one asset, so there is no brick style or optimizer to choose"
+                );
+            }
+        }
+        // `--micro` is the one that also changes what `--size` COUNTS, so it
+        // gets its own message: taken literally it would shrink the map 5x.
+        if matches.is_present("micro") {
+            warn!(
+                "{mode} ignores --micro; --size stays a count of STUDS per pixel. --terrain \
+                 already builds from micro bricks, and --rampify needs full-size ramp assets"
+            );
+        }
+        if matches.is_present("img") {
+            warn!("{mode} ignores --img: a flat image has no terrain to slope");
+        }
+    }
+    let blocks = surface == SurfaceMode::Blocks;
+
     // output options
     let options = GenOptions {
-        size: size * if matches.is_present("micro") { 1 } else { 5 },
+        size: size * if matches.is_present("micro") && blocks { 1 } else { 5 },
         scale,
         cull: matches.is_present("cull"),
         asset: if matches.is_present("micro") {
@@ -1428,16 +1496,17 @@ fn run_heightmap(
         } else {
             PB_DEFAULT_BRICK
         },
-        micro: matches.is_present("micro"),
-        stud: matches.is_present("stud"),
+        micro: matches.is_present("micro") && blocks,
+        stud: matches.is_present("stud") && blocks,
         snap: matches.is_present("snap"),
-        img: matches.is_present("img"),
+        img: matches.is_present("img") && blocks,
         glow: matches.is_present("glow"),
         hdmap: matches.is_present("hdmap"),
         lrgb: matches.is_present("lrgb"),
         nocollide: matches.is_present("nocollide"),
         quadtree: true,
         greedy: matches.is_present("greedy"),
+        surface,
     };
 
     info!("Reading image files");
@@ -1493,7 +1562,14 @@ fn run_heightmap(
     };
 
     info!("Writing Save to {}", out_file);
-    let data = bricks_to_save(bricks);
+    let mut data = bricks_to_save(bricks);
+    // A prefab bundle and a world bundle differ only in metadata (`level_type`
+    // plus the pivot/bounds block `make_prefab` computes from the brick
+    // bounding box), so this is applied to the finished world rather than
+    // threaded through every generator.
+    if matches.is_present("prefab") {
+        data.make_prefab();
+    }
     if let Err(e) = write_world(&data, &out_file) {
         fail!("{e}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,10 +316,10 @@ fn main() {
         );
     }
 
-    // The heightmap-only flags, named out loud when another renderer has
-    // already won the dispatch below. Same policy as `--subtitles` above: a
-    // user who passed `--terrain --text` and got a glyph export would
-    // reasonably conclude the terrain renderer was broken.
+    // These options apply to the heightmap only. If another renderer wins the
+    // selection below, the code tells the user. This is the rule that
+    // `--subtitles` above uses: a user who gives `--terrain --text` and gets a
+    // text export would think that the terrain renderer is defective.
     if ["midi", "audiomode", "animmode", "text"]
         .iter()
         .any(|m| matches.is_present(m))
@@ -1433,9 +1433,9 @@ fn run_heightmap(
         Err(e) => fail(e),
     };
 
-    // The two sloped surface renderers. Refused together rather than silently
-    // preferring one: they are different techniques with different brick
-    // families, and a user who passed both has one of them in mind.
+    // The two sloped renderers. The code refuses both together and does not
+    // select one of them. They are different methods with different bricks.
+    // A user who gives both must select one of them.
     let surface = match (matches.is_present("terrain"), matches.is_present("rampify")) {
         (true, true) => fail!(
             "--terrain and --rampify are two different smoothing techniques and cannot be \
@@ -1446,10 +1446,11 @@ fn run_heightmap(
         (false, true) => SurfaceMode::Rampify,
         (false, false) => SurfaceMode::Blocks,
     };
-    // Every flag below shapes a FLAT-TOPPED prism, which is the one thing a
-    // sloped renderer does not build. Named out loud one at a time rather than
-    // dropped, the same way the audio branch names the flags it cannot honour:
-    // a render that silently ignored `--greedy` would look like it worked.
+    // Each option below controls a box with a FLAT TOP, which is the one
+    // thing that a sloped renderer does not make. The code names each option,
+    // in the same way as the audio part names the options that it cannot use.
+    // A render that ignored `--greedy` without a message would appear
+    // correct.
     if surface != SurfaceMode::Blocks {
         let mode = if surface == SurfaceMode::Terrain { "--terrain" } else { "--rampify" };
         for (flag, name) in [
@@ -1466,8 +1467,8 @@ fn run_heightmap(
                 );
             }
         }
-        // `--micro` is the one that also changes what `--size` COUNTS, so it
-        // gets its own message: taken literally it would shrink the map 5x.
+        // `--micro` also changes what `--size` COUNTS, so it gets its own
+        // message. To obey it would make the map 5 times smaller.
         if matches.is_present("micro") {
             warn!(
                 "{mode} ignores --micro; --size stays a count of STUDS per pixel. --terrain \
@@ -1563,10 +1564,10 @@ fn run_heightmap(
 
     info!("Writing Save to {}", out_file);
     let mut data = bricks_to_save(bricks);
-    // A prefab bundle and a world bundle differ only in metadata (`level_type`
-    // plus the pivot/bounds block `make_prefab` computes from the brick
-    // bounding box), so this is applied to the finished world rather than
-    // threaded through every generator.
+    // A prefab bundle and a world bundle differ in their metadata only. The
+    // difference is `level_type` and the block of pivots and bounds that
+    // `make_prefab` calculates from the brick positions. The code thus changes
+    // the completed world and does not send this option to each generator.
     if matches.is_present("prefab") {
         data.make_prefab();
     }

--- a/src/opt/generate.rs
+++ b/src/opt/generate.rs
@@ -1,4 +1,6 @@
-use super::{BitMask, QuadTree, greedy_mesh_binary_plane};
+use super::{
+    BitMask, QuadTree, gen_rampify_heightmap, gen_terrain_heightmap, greedy_mesh_binary_plane,
+};
 use crate::map::*;
 use crate::util::*;
 use brdb::{
@@ -34,6 +36,20 @@ pub fn gen_opt_heightmap<F: Fn(f32) -> bool>(
     options: GenOptions,
     progress_f: F,
 ) -> Result<Vec<Brick>, String> {
+    // The sloped renderers replace brick emission wholesale -- they pick their
+    // own assets from a shape grammar rather than stacking `options.asset` --
+    // so they are chosen BEFORE the quadtree/greedy split, which is a choice
+    // between two ways of merging flat-topped prisms.
+    match options.surface {
+        SurfaceMode::Terrain => {
+            return gen_terrain_heightmap(heightmap, colormap, options, progress_f);
+        }
+        SurfaceMode::Rampify => {
+            return gen_rampify_heightmap(heightmap, colormap, options, progress_f);
+        }
+        SurfaceMode::Blocks => {}
+    }
+
     // Use greedy mesh if requested
     if options.greedy {
         return gen_greedy_heightmap(heightmap, colormap, options, progress_f);

--- a/src/opt/generate.rs
+++ b/src/opt/generate.rs
@@ -36,10 +36,11 @@ pub fn gen_opt_heightmap<F: Fn(f32) -> bool>(
     options: GenOptions,
     progress_f: F,
 ) -> Result<Vec<Brick>, String> {
-    // The sloped renderers replace brick emission wholesale -- they pick their
-    // own assets from a shape grammar rather than stacking `options.asset` --
-    // so they are chosen BEFORE the quadtree/greedy split, which is a choice
-    // between two ways of merging flat-topped prisms.
+    // The sloped renderers replace the full step that makes the bricks. They
+    // select their own assets from a set of shapes and do not use
+    // `options.asset`. The code thus selects them BEFORE the quadtree or
+    // greedy choice, which is a choice between two ways to join boxes with
+    // flat tops.
     match options.surface {
         SurfaceMode::Terrain => {
             return gen_terrain_heightmap(heightmap, colormap, options, progress_f);

--- a/src/opt/mod.rs
+++ b/src/opt/mod.rs
@@ -1,7 +1,11 @@
 mod generate;
 mod greedy;
 mod quad;
+mod rampify;
+mod terrain;
 
 pub use generate::*;
 pub use greedy::*;
 pub use quad::*;
+pub use rampify::*;
+pub use terrain::*;

--- a/src/opt/rampify.rs
+++ b/src/opt/rampify.rs
@@ -1,30 +1,35 @@
-//! Wrapperup's rampifier, over a heightmap's column field.
+//! The Wrapperup rampifier, over the height columns of a heightmap.
 //!
-//! The slope-selection algorithm is Wrapperup/rampifier's, by way of the
-//! BRDB-native port in `obj2brz` (`crates/obj2brz/src/rampify.rs`): scan the
-//! surface, fit the longest ramp that meets the terrain rising in front of it,
-//! prefer corner ramps at convex and concave turns, then fill whatever is left
-//! with plain bricks. The fitting rules, the run/rise limits and the brick
-//! geometry are all carried over unchanged.
+//! The algorithm that selects the slopes is the Wrapperup/rampifier
+//! algorithm. It comes here from the BRDB version in `obj2brz`
+//! (`crates/obj2brz/src/rampify.rs`): examine the surface, fit the longest
+//! ramp that touches the ground that goes up in front of it, use corner ramps
+//! at convex turns and at concave turns, then fill the remainder with usual
+//! bricks. The fit rules, the limits on the run and the rise, and the brick
+//! geometry are all the same as in that version.
 //!
-//! What is NOT carried over is the dense voxel grid. `obj2brz` rampifies an
-//! arbitrary mesh, so it materialises one cell per voxel of the bounding box
-//! and caps the model at 64M of them. A heightmap is a HEIGHT FIELD -- a column
-//! is solid from the ground to its top and empty above -- so occupancy is a
-//! comparison rather than a lookup, and a 4096x4096 map at 255 plates costs a
-//! `Vec<i32>` per column instead of the four terabytes its bounding box would
-//! ask for. Two consequences fall out of that and are relied on below:
+//! The dense grid of voxels is NOT the same. `obj2brz` makes ramps from any
+//! mesh, so it makes one cell for each voxel of the bounding box and refuses a
+//! model of more than 64M cells. A heightmap is a HEIGHT FIELD: a column is
+//! solid from the ground to its top and is empty above the top. To find the
+//! material is thus a comparison and not a lookup, and a map of 4096x4096 at
+//! 255 plates costs one `Vec<i32>` for each column. The bounding box would
+//! ask for four terabytes. Two results of this come from that fact and the
+//! code below uses them:
 //!
-//! * **Only the top cell of a column can anchor a slope.** Both `fit_ramp` and
-//!   `fit_corner` refuse a cell with anything above it, so the whole
-//!   ascending-Z scan reduces to visiting each column once, in height order.
-//! * **There is no enclosed air and no underside.** The mesh rampifier floods
-//!   air to find the inside of a watertight model and fits upside-down ramps
-//!   under overhangs; a height field has neither, so only the floor pass runs.
+//! * **Only the top cell of a column can hold a slope.** `fit_ramp` and
+//!   `fit_corner` both refuse a cell that has material above it. The full scan
+//!   up the Z axis thus becomes one visit to each column, in the sequence of
+//!   the heights.
+//! * **There is no closed air and no lower face.** The mesh rampifier fills
+//!   air to find the inside of a closed model, and it puts ramps upside down
+//!   below an overhang. A height field has neither, so only the floor pass
+//!   runs.
 //!
 //! One voxel is one pixel wide (`GenOptions::size` half extents) and one plate
-//! tall (4 units). `--vertical` is read as units and rounded to a whole number
-//! of plates, because a `PB_DefaultRamp`'s rise is quantized to plates.
+//! high (4 units). The code reads `--vertical` as units and changes it to a
+//! whole number of plates, because the rise of a `PB_DefaultRamp` must be a
+//! whole number of plates.
 
 use crate::map::*;
 use crate::util::*;
@@ -41,17 +46,17 @@ use brdb::{
 use log::info;
 use std::collections::HashMap;
 
-/// Longest run a ramp may span, in cells. Wrapperup's value.
+/// The longest run of a ramp, in cells. This is the Wrapperup value.
 const RAMP_MAX_RUN: i32 = 4;
-/// Tallest rise a ramp may span, in cells. Wrapperup's value.
+/// The largest rise of a ramp, in cells. This is the Wrapperup value.
 const RAMP_MAX_RISE: i32 = 12;
-/// Vertical units in one cell: a plate.
+/// The number of vertical units in one cell. One cell is one plate.
 const CELL_UNITS: i32 = 4;
-/// The largest half extent a procedural brick may carry.
+/// The largest half extent that a procedural brick can hold.
 const MAX_HALF_EXTENT: i32 = 250;
 
-/// A cell coordinate. X and Y index the pixel grid; Z counts plates up from the
-/// ground.
+/// One cell position. X and Y give the pixel, and Z counts the plates above
+/// the ground.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 struct Cell(i32, i32, i32);
 
@@ -77,9 +82,9 @@ impl std::ops::Mul<i32> for Cell {
 }
 
 impl Cell {
-    /// Which way a ramp of this rotation runs UPHILL. Rotation zero steps down
-    /// toward `+X`, so its uphill direction is `-X`; the rest are quarter turns
-    /// counter-clockwise around `+Z`.
+    /// The direction in which a ramp with this rotation goes UP. Rotation zero
+    /// goes down at `+X`, so it goes up at `-X`. The other rotations are
+    /// quarter turns counterclockwise around `+Z`.
     fn forward(rotation: Rotation) -> Self {
         match rotation {
             Rotation::Deg0 => Self(-1, 0, 0),
@@ -99,17 +104,17 @@ fn next_rotation(rotation: Rotation) -> Rotation {
     }
 }
 
-/// The height field the rampifier reads, plus the cells already claimed by a
-/// slope.
+/// The height field that the rampifier reads, with the cells that a slope
+/// already uses.
 struct Field {
     width: i32,
     height: i32,
-    /// Solid cells in each column: the column occupies `0..cells`.
+    /// The number of solid cells in each column. The column fills `0..cells`.
     cells: Vec<i32>,
     colors: Vec<[u8; 4]>,
-    /// Inclusive Z ranges consumed by an emitted slope, per column. A column
-    /// carries at most a handful, so a small `Vec` beats a per-cell bitmap by
-    /// orders of magnitude on a real map.
+    /// The Z ranges of each column that a slope uses, with both ends included.
+    /// A column holds only a small number of these, so a short `Vec` uses much
+    /// less memory than one bit for each cell on a real map.
     claimed: Vec<Vec<(i32, i32)>>,
 }
 
@@ -135,9 +140,9 @@ impl Field {
         })
     }
 
-    /// How many cells of solid material sit at and above `cell`, capped at 31.
-    /// `i32::MIN` when the cell itself is air, so an empty neighbour can never
-    /// win the `max_by_key` in [`Self::best_rotation`].
+    /// The number of solid cells at `cell` and above it, to a maximum of 31.
+    /// The result is `i32::MIN` if the cell is empty. An empty adjacent cell
+    /// can thus never win the `max_by_key` in [`Self::best_rotation`].
     fn slope_height(&self, cell: Cell) -> i32 {
         if !self.exists(cell) {
             return i32::MIN;
@@ -145,8 +150,9 @@ impl Field {
         (self.column(cell) - cell.2).min(31)
     }
 
-    /// The direction whose terrain rises highest in front of `cell` while the
-    /// cell BEHIND it is open, i.e. the way a ramp here should climb.
+    /// The direction in which the ground in front of `cell` goes up the most,
+    /// while the cell BEHIND it is empty. A ramp at this cell must go up in
+    /// that direction.
     fn best_rotation(&self, cell: Cell) -> Option<Rotation> {
         if self.exists(cell + Cell(0, 0, 1)) {
             return None;
@@ -164,8 +170,8 @@ impl Field {
         .and_then(|(height, rotation)| (height > 0).then_some(rotation))
     }
 
-    /// The run and rise of the straight ramp anchored at `cell` climbing
-    /// `rotation`, or `None` where no ramp fits.
+    /// The run and the rise of the straight ramp that starts at `cell` and
+    /// goes up at `rotation`. The result is `None` if no ramp fits.
     fn fit_ramp(&self, cell: Cell, rotation: Rotation) -> Option<(i32, i32)> {
         let forward = Cell::forward(rotation);
         let up = Cell(0, 0, 1);
@@ -194,8 +200,8 @@ impl Field {
                 break;
             }
         }
-        // A summit the ramp runs off the far side of gets one more cell of
-        // rise, so a ridge is capped rather than left a plate short.
+        // A top that the ramp goes over gets one more cell of rise. A ridge
+        // thus gets a full top and does not stay one plate too low.
         let mut add_one = 0;
         for step in 1..RAMP_MAX_RUN {
             let beyond = cell + up * rise + forward * (run + step);
@@ -210,15 +216,16 @@ impl Field {
         (rise > 1).then_some((run + 1, rise - 1))
     }
 
-    /// The runs along each wall axis and the rise of a corner ramp whose two
-    /// high walls face `rotation` and `rotation + 90`, with `cell` as the low
-    /// outer corner.
+    /// The runs along each wall axis and the rise of a corner ramp. The two
+    /// high walls point at `rotation` and at `rotation + 90`, and `cell` is
+    /// the low outer corner.
     ///
-    /// An OUTER corner (a convex contour turn) has open cells behind both wall
-    /// axes and rising terrain only past the far diagonal. An INNER corner (a
-    /// concave turn) sits where the edge wraps the other way: the cells behind
-    /// it are still edge, only the diagonal between them is open, and the
-    /// terrain rises along the whole far row and column.
+    /// An OUTER corner is a convex turn. It has empty cells behind both wall
+    /// axes, and the ground goes up only after the far diagonal cell. An INNER
+    /// corner is a concave turn. The edge turns the other way there: the cells
+    /// behind it are still part of the edge, only the diagonal between them is
+    /// empty, and the ground goes up along the full far row and the full far
+    /// column.
     fn fit_corner(&self, cell: Cell, rotation: Rotation, inner: bool) -> Option<(i32, i32, i32)> {
         let up = Cell(0, 0, 1);
         let forward_a = Cell::forward(rotation);
@@ -238,15 +245,16 @@ impl Field {
         }
         let (run_a, rise_a) = self.fit_ramp(cell, rotation)?;
         let (run_b, rise_b) = self.fit_ramp(cell, next_rotation(rotation))?;
-        // The two edge fits rarely agree exactly on rough terrain; the lower
-        // rise still meets both neighbouring slopes.
+        // On rough ground the two edge fits are usually different. The lower
+        // rise still touches both adjacent slopes.
         let rise = rise_a.min(rise_b);
 
-        // An outer corner's surface is the INTERSECTION of the two straight
-        // ramps, so it only reaches full height at the far diagonal cell; an
-        // inner corner's is their UNION and is full height along the whole far
-        // row and column. Those cells may hold the rising terrain; everywhere
-        // else the footprint must be flat with air above it.
+        // The surface of an outer corner is where the two straight ramps
+        // AGREE, so it is at the full height only at the far diagonal cell.
+        // The surface of an inner corner is where EITHER ramp is high, so it
+        // is at the full height along the full far row and the full far
+        // column. Those cells can hold the ground that goes up. At each other
+        // cell the area must be flat, with air above it.
         let clear = |cells_a: i32, cells_b: i32| {
             for i in 0..cells_a {
                 for j in 0..cells_b {
@@ -268,8 +276,9 @@ impl Field {
             }
             true
         };
-        // The full-run footprint is often obstructed on rough terrain, so fall
-        // back to the largest clear rectangle that still makes a corner (2x2).
+        // On rough ground something usually blocks the area of the full run.
+        // The code then uses the largest empty rectangle that is still a
+        // corner, which is 2x2.
         let mut best: Option<(i32, i32)> = None;
         for cells_a in 2..=run_a {
             for cells_b in 2..=run_b {
@@ -281,9 +290,9 @@ impl Field {
         best.map(|(cells_a, cells_b)| (cells_a, cells_b, rise))
     }
 
-    /// Claim every cell in a box and report the colour that dominates the solid
-    /// ones. A slope covers several columns, and taking the anchor's colour
-    /// instead would tint every ramp with the colour of its lowest pixel.
+    /// Use each cell in a box, and give the color that occurs most in the
+    /// solid cells. A slope covers more than one column. To use the color of
+    /// the first cell would give each ramp the color of its lowest pixel.
     fn claim(&mut self, origin: Cell, axes: [(Cell, i32); 2], rise: i32) -> Color {
         let mut counts = HashMap::<[u8; 4], usize>::new();
         for i in 0..axes[0].1 {
@@ -314,14 +323,15 @@ impl Field {
     }
 }
 
-/// Where the rampifier's cell grid sits in world units, and how bricks are
-/// styled. Split out so the geometry can be exercised without a `GenOptions`.
+/// The position of the cell grid in world units, and the appearance of the
+/// bricks. It is a separate type, so a test can use the geometry without a
+/// `GenOptions`.
 struct Layout {
-    /// Half extent of one cell in X and Y, in units.
+    /// The half extent of one cell in X and Y, in units.
     half: i32,
     offset_x: i32,
     offset_y: i32,
-    /// World Z of the bottom of cell layer zero.
+    /// The world Z of the bottom of cell layer zero.
     z_floor: i32,
     glow: bool,
     collision: brdb::Collision,
@@ -351,13 +361,14 @@ impl Layout {
     }
 }
 
-/// Emit a straight ramp (or a one-cell wedge) anchored at `cell`.
+/// Make a straight ramp at `cell`, or a wedge if the run is one cell.
 ///
-/// The anchor is the ramp's LOW end and the piece extends `run` cells along the
-/// rotation's forward axis, which for two of the four rotations runs toward
-/// NEGATIVE X or Y. The per-rotation offsets below place the brick's centre
-/// accordingly; they are the ported `create_ramp` offsets with `obj2brz`'s
-/// hard-coded stud (5 units half, 10 full) generalised to `Layout::half`.
+/// `cell` is the LOW end of the ramp. The brick continues for `run` cells
+/// along the forward axis of the rotation. For two of the four rotations that
+/// axis points at NEGATIVE X or NEGATIVE Y. The values below put the center of
+/// the brick at the correct position for each rotation. They come from
+/// `create_ramp`, but the fixed stud of `obj2brz` (5 units for a half, 10 for
+/// the full width) becomes `Layout::half`.
 fn ramp_brick(
     layout: &Layout,
     cell: Cell,
@@ -397,7 +408,8 @@ fn ramp_brick(
     }
     position.z += size.z as i32;
     layout.brick(
-        // A single-cell run has no ramp asset; the wedge is its one-cell form.
+        // There is no ramp asset for a run of one cell. The wedge is the ramp
+        // of one cell.
         if run < 2 {
             PB_DEFAULT_WEDGE
         } else {
@@ -410,7 +422,7 @@ fn ramp_brick(
     )
 }
 
-/// Emit a corner ramp anchored at its low outer corner.
+/// Make a corner ramp. Its position is its low outer corner.
 fn corner_brick(
     layout: &Layout,
     cell: Cell,
@@ -422,8 +434,8 @@ fn corner_brick(
     let forward_a = Cell::forward(rotation);
     let forward_b = Cell::forward(next_rotation(rotation));
     let far = cell + forward_a * (run_a - 1) + forward_b * (run_b - 1);
-    // Local X follows the first wall axis, so a quarter turn swaps which run
-    // spans world X.
+    // The local X axis follows the first wall axis. A quarter turn thus
+    // changes which run is along the world X axis.
     let (x_cells, y_cells) = if forward_a.0 != 0 {
         (run_a, run_b)
     } else {
@@ -453,8 +465,8 @@ fn corner_brick(
     )
 }
 
-/// Generate a rampified heightmap: full-size ramps, wedges and ramp corners
-/// fitted onto the column field's surface, with plain bricks under and beside
+/// Make a heightmap with ramps: usual ramps, wedges and corner ramps on the
+/// surface of the column field, with plain bricks below them and beside
 /// them.
 pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
     heightmap: &dyn Heightmap,
@@ -479,7 +491,8 @@ pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
         return Err("Heightmap is empty".to_string());
     }
 
-    // A ramp's rise is quantized to plates, so the vertical scale is too.
+    // The rise of a ramp is a whole number of plates, so the vertical scale
+    // must also be a whole number of plates.
     let plates_per_shade = ((options.scale as i32 + CELL_UNITS / 2) / CELL_UNITS).max(1);
     let effective = plates_per_shade * CELL_UNITS;
     if effective != options.scale as i32 {
@@ -508,8 +521,9 @@ pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
             field.cells[index] = if options.cull && (shade == 0 || color[3] == 0) {
                 0
             } else {
-                // `+ 1` so a black pixel is still one plate of ground rather
-                // than a hole, matching the minimum slab the blocky modes emit.
+                // The `+ 1` gives a black pixel one plate of ground and not a
+                // hole. This agrees with the smallest brick that the other
+                // modes make.
                 (shade.saturating_mul(plates_per_shade)).saturating_add(1)
             };
         }
@@ -520,18 +534,18 @@ pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
         half: options.size as i32,
         offset_x: -(width as i32 * options.size as i32),
         offset_y: -(height as i32 * options.size as i32),
-        // A one-plate column's TOP lands where the blocky modes put the top of
-        // a zero-height cell, so the two modes share a ground plane.
+        // The TOP of a column of one plate is where the other modes put the
+        // top of a cell of height zero. The modes thus share a ground level.
         z_floor: options.base_height() - 5 - CELL_UNITS,
         glow: options.glow,
         collision: options.collision(),
     };
 
-    // The full ascending-Z scan of the mesh rampifier, reduced to its only
-    // productive cells: `fit_ramp` and `fit_corner` both refuse a cell with
-    // anything above it, so on a height field the sole candidate per column is
-    // its top. Sorting by (height, y, x) visits them in exactly the order the
-    // z/y/x loop nest would have.
+    // The mesh rampifier scans up the Z axis. Only some cells can give a
+    // result: `fit_ramp` and `fit_corner` both refuse a cell that has material
+    // above it, so on a height field the only candidate in a column is its
+    // top. To sort by height and then by position visits the cells in the same
+    // sequence as the loops over z, y and x.
     let mut anchors: Vec<u32> = (0..count as u32)
         .filter(|i| field.cells[*i as usize] > 0)
         .collect();
@@ -544,8 +558,8 @@ pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
     let mut ramps = 0usize;
     let mut corners = 0usize;
 
-    // Corners run first: a straight ramp along either edge next to a convex
-    // corner would otherwise consume the corner's own footprint.
+    // The corners come first. If they did not, a straight ramp along an edge
+    // beside a convex corner would use the cells of the corner.
     info!("Fitting corner ramps");
     for (n, index) in anchors.iter().enumerate() {
         let index = *index as usize;
@@ -629,14 +643,14 @@ pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
     Ok(bricks)
 }
 
-/// Fill everything the slopes did not claim with plain bricks, merging equal
-/// spans across neighbouring columns.
+/// Fill each cell that the slopes did not use with plain bricks, and join
+/// equal Z ranges in adjacent columns.
 ///
-/// The mesh rampifier grows a box cell by cell because its colours vary in Z.
-/// A height field's colour is a property of the COLUMN, so what is left of a
-/// column after the slopes is a handful of Z spans, and two neighbouring
-/// columns merge exactly when a span and a colour both match. That turns the
-/// per-cell growth into one pass over spans.
+/// The mesh rampifier makes a box one cell at a time, because its colors
+/// change along Z. But in a height field the color belongs to the COLUMN. What
+/// stays after the slopes is thus a small number of Z ranges in each column,
+/// and two adjacent columns join if a range and a color both agree. One pass
+/// over the ranges then replaces the growth cell by cell.
 fn fill_gaps<F: Fn(f32) -> bool>(
     field: &Field,
     layout: &Layout,
@@ -654,9 +668,9 @@ fn fill_gaps<F: Fn(f32) -> bool>(
     let max_run = (MAX_HALF_EXTENT / layout.half).max(1);
     let mut emitted = 0usize;
 
-    // A neighbouring column joins this box only when it offers the SAME span,
-    // still unclaimed, under the same colour. Spans within one column are
-    // disjoint, so at most one can match.
+    // An adjacent column joins this box only if it has the SAME range, if no
+    // brick uses that range, and if the color agrees. The ranges in one column
+    // do not touch, so one range at most can agree.
     let matching =
         |index: usize, span: (i32, i32), color: [u8; 4], taken: &[Vec<bool>]| -> Option<usize> {
             if field.colors[index] != color {
@@ -699,8 +713,8 @@ fn fill_gaps<F: Fn(f32) -> bool>(
                             index + (run_y as usize * field.width as usize) + dx as usize;
                         match matching(neighbour, span, color, &taken) {
                             Some(j) => row.push((neighbour, j)),
-                            // A partial row is discarded whole: the box has to
-                            // stay rectangular.
+                            // The code rejects the full row, because the box
+                            // must stay rectangular.
                             None => break 'rows,
                         }
                     }
@@ -744,8 +758,9 @@ fn fill_gaps<F: Fn(f32) -> bool>(
     Ok(emitted)
 }
 
-/// One column's solid Z spans minus everything a slope claimed, split so no
-/// span exceeds the tallest brick the format can carry.
+/// The solid Z ranges of one column, less each range that a slope uses. The
+/// code divides a range that is higher than the largest brick that the format
+/// holds.
 fn unclaimed_spans(field: &Field, index: usize) -> Vec<(i32, i32)> {
     let top = field.cells[index];
     if top <= 0 {
@@ -788,8 +803,8 @@ fn unclaimed_spans(field: &Field, index: usize) -> Vec<(i32, i32)> {
 mod tests {
     use super::*;
 
-    /// A field built from a closure over `(x, y)` giving each column's plate
-    /// count, all one colour.
+    /// A field where a closure gives the number of plates in each column. Each
+    /// column has the same color.
     fn field(width: i32, height: i32, column: impl Fn(i32, i32) -> i32) -> Field {
         let count = (width * height) as usize;
         let mut cells = vec![0; count];
@@ -818,8 +833,7 @@ mod tests {
         }
     }
 
-    /// `brdb::Rotation` carries no `PartialEq`, so assertions compare quarter
-    /// turns instead.
+    /// `brdb::Rotation` has no `PartialEq`, so the tests compare quarter turns.
     fn turn(rotation: Option<Rotation>) -> Option<u8> {
         rotation.map(|r| match r {
             Rotation::Deg0 => 0,
@@ -833,42 +847,59 @@ mod tests {
         Cell(x, y, field.cells[(y * field.width + x) as usize] - 1)
     }
 
-    /// The rampifier's whole premise: a staircase becomes a slope. A ramp must
-    /// fit at the foot of a rising run, and it must climb toward the rise.
+    fn rotations() -> [Rotation; 4] {
+        [
+            Rotation::Deg0,
+            Rotation::Deg90,
+            Rotation::Deg180,
+            Rotation::Deg270,
+        ]
+    }
+
+    fn asset(brick: &Brick) -> &str {
+        let BrickType::Procedural { asset, .. } = &brick.asset else {
+            panic!("rampify makes procedural bricks only")
+        };
+        asset.as_ref()
+    }
+
+    /// The purpose of the rampifier: steps become a slope. A ramp must fit at
+    /// the bottom of a run that goes up, and it must go up at the high side.
     #[test]
     fn a_rising_staircase_fits_a_ramp_climbing_it() {
-        // Columns get taller with +X, so the uphill direction is +X: rotation
-        // 180, whose forward is (1, 0, 0).
+        // The columns get higher at +X, so the ramp goes up at +X. That is
+        // rotation 180, whose forward direction is (1, 0, 0).
         let field = field(8, 3, |x, _| 1 + x);
         let anchor = top(&field, 0, 1);
         assert_eq!(turn(field.best_rotation(anchor)), Some(2));
         let (run, rise) = field
             .fit_ramp(anchor, Rotation::Deg180)
-            .expect("a ramp fits at the foot of a staircase");
-        assert!(run >= 2 && rise >= 1, "got run {run}, rise {rise}");
+            .expect("a ramp fits at the bottom of the steps");
+        assert!(run >= 2 && rise >= 1, "the fit gave run {run} and rise {rise}");
     }
 
-    /// A cell with material above it can never anchor a slope. This is what
-    /// licenses visiting one anchor per column instead of scanning every Z.
+    /// A cell that has material above it can never hold a slope. This rule
+    /// permits one visit to each column in place of a scan of each Z value.
     #[test]
     fn only_the_top_cell_of_a_column_can_anchor_a_slope() {
         let field = field(8, 3, |x, _| 1 + x);
         let buried = Cell(3, 1, 0);
         assert!(
             field.exists(buried + Cell(0, 0, 1)),
-            "the test cell must be buried"
+            "the test cell must have material above it"
         );
         assert_eq!(turn(field.best_rotation(buried)), None);
         assert_eq!(field.fit_corner(buried, Rotation::Deg0, false), None);
         assert_eq!(field.fit_corner(buried, Rotation::Deg0, true), None);
     }
 
-    /// Inside a flat plain there is nothing to climb, so no cell may slope.
+    /// Inside a flat plain there is nothing to go up, so no cell can slope.
     ///
-    /// The RIM is deliberately excluded: a column at the map's edge has open
-    /// air behind it and material in front, which is a one-plate step, and the
-    /// rampifier bevels it exactly as the mesh version bevels the edge of a
-    /// slab. That is a property of the edge, not of the plain.
+    /// The edge of the map is not part of this test. A column at the edge has
+    /// air behind it and material in front of it, which is a step of one
+    /// plate. The rampifier cuts that edge, in the same way as the mesh
+    /// version cuts the edge of a slab. That is a property of the edge and not
+    /// of the plain, and the last line holds it.
     #[test]
     fn the_interior_of_a_flat_plain_fits_no_ramp_at_all() {
         let field = field(8, 8, |_, _| 3);
@@ -877,55 +908,41 @@ mod tests {
                 assert_eq!(
                     turn(field.best_rotation(top(&field, x, y))),
                     None,
-                    "({x}, {y}) is surrounded by its own height and must not slope"
+                    "the cell ({x}, {y}) has the same height as each adjacent cell"
                 );
             }
         }
-        // ...and the rim really does bevel, so the exclusion above is a
-        // statement about this renderer rather than a hole in the test.
         assert!(turn(field.best_rotation(top(&field, 0, 4))).is_some());
     }
 
-    /// A convex plateau turn is what the corner asset exists for; a straight
-    /// edge must never match one, or corners would eat the whole ridge.
+    /// A corner asset is for a convex turn. A straight edge must never fit
+    /// one, or the corners would use the full ridge.
     #[test]
     fn a_convex_plateau_turn_fits_a_corner_and_a_straight_edge_does_not() {
-        // A 12x12 plain with a raised quadrant, so the plateau's outer corner
-        // is a convex turn and its edges are straight. The anchor is the
-        // plateau's own corner cell -- a corner ramp BEVELS the turn it sits
-        // on, it does not sit on the ground beside it.
+        // A plain of 12x12 with one high quarter. The outer corner of the high
+        // part is a convex turn, and its edges are straight. The test starts
+        // at the corner cell of the high part, because a corner ramp cuts the
+        // turn that it is on. It does not sit on the ground beside it.
         let field = field(12, 12, |x, y| if x >= 6 && y >= 6 { 4 } else { 1 });
         let corner = top(&field, 6, 6);
-        let fits = [
-            Rotation::Deg0,
-            Rotation::Deg90,
-            Rotation::Deg180,
-            Rotation::Deg270,
-        ]
-        .into_iter()
-        .any(|r| field.fit_corner(corner, r, false).is_some());
         assert!(
-            fits,
-            "the convex plateau corner must fit an outer corner ramp"
+            rotations()
+                .into_iter()
+                .any(|r| field.fit_corner(corner, r, false).is_some()),
+            "the convex corner of the high part must fit an outer corner ramp"
         );
 
         let straight = top(&field, 6, 9);
-        let straight_fits = [
-            Rotation::Deg0,
-            Rotation::Deg90,
-            Rotation::Deg180,
-            Rotation::Deg270,
-        ]
-        .into_iter()
-        .any(|r| field.fit_corner(straight, r, false).is_some());
         assert!(
-            !straight_fits,
-            "a straight plateau edge must be a plain ramp, not a corner"
+            !rotations()
+                .into_iter()
+                .any(|r| field.fit_corner(straight, r, false).is_some()),
+            "a straight edge must be a usual ramp and not a corner"
         );
     }
 
-    /// Claiming a slope's cells must remove them from the fill pass, or every
-    /// ramp would be buried inside the blocks meant to sit under it.
+    /// A slope must remove its cells from the fill pass. If it did not, each
+    /// ramp would be inside the blocks that must go below it.
     #[test]
     fn claimed_cells_do_not_come_back_as_fill_blocks() {
         let mut field = field(8, 3, |x, _| 1 + x);
@@ -937,29 +954,29 @@ mod tests {
             rise,
         );
 
-        let index = (1 * field.width + anchor.0) as usize;
         assert!(field.is_ramp(anchor));
-        let spans = unclaimed_spans(&field, index);
+        let spans = unclaimed_spans(&field, (field.width + anchor.0) as usize);
         assert!(
             spans
                 .iter()
                 .all(|(low, high)| anchor.2 < *low || anchor.2 > *high),
-            "the anchor cell is still offered to the fill pass: {spans:?}"
+            "the fill pass can still use the cell of the ramp: {spans:?}"
         );
     }
 
+    /// A column that is higher than one brick must become more than one brick.
+    /// Those bricks must fill the column, with no gap and no overlap.
     #[test]
     fn a_tall_column_is_split_into_legal_bricks() {
         let field = field(1, 1, |_, _| 1000);
         let spans = unclaimed_spans(&field, 0);
-        assert!(spans.len() > 1, "a 1000-plate column must be split");
+        assert!(spans.len() > 1, "a column of 1000 plates must be divided");
         for (low, high) in &spans {
             assert!(
                 (high - low + 1) * 2 <= MAX_HALF_EXTENT,
-                "span {low}..={high} exceeds the largest legal brick"
+                "the range {low}..={high} is larger than the largest legal brick"
             );
         }
-        // No gaps and no overlap: the splits must still tile the column.
         assert_eq!(spans[0].0, 0);
         assert_eq!(spans.last().unwrap().1, 999);
         for pair in spans.windows(2) {
@@ -967,7 +984,8 @@ mod tests {
         }
     }
 
-    /// A flat plain must merge into a few big blocks rather than one per pixel.
+    /// A flat plain must become a small number of large blocks and not one
+    /// block for each pixel.
     #[test]
     fn the_fill_pass_merges_equal_columns_into_boxes() {
         let field = field(16, 16, |_, _| 2);
@@ -976,70 +994,47 @@ mod tests {
         assert_eq!(filled, bricks.len());
         assert!(
             bricks.len() < 32,
-            "256 identical columns collapsed to only {} brick(s)",
+            "256 equal columns gave {} brick(s)",
             bricks.len()
         );
     }
 
-    /// One-cell runs have no ramp asset; the wedge is the one-cell ramp.
+    /// The geometry of an emitted ramp: the correct asset for its length, and
+    /// a center over the cells that it covers.
+    ///
+    /// Two of the four rotations go at a NEGATIVE axis, which is where an
+    /// error in the center is easy to make.
     #[test]
-    fn a_single_cell_run_uses_the_wedge_asset() {
-        let wedge = ramp_brick(
-            &layout(),
-            Cell(0, 0, 0),
-            1,
-            2,
-            Rotation::Deg0,
-            Color::new(1, 2, 3),
-        );
-        let ramp = ramp_brick(
-            &layout(),
-            Cell(0, 0, 0),
-            3,
-            2,
-            Rotation::Deg0,
-            Color::new(1, 2, 3),
-        );
-        let BrickType::Procedural {
-            asset: wedge_asset, ..
-        } = &wedge.asset
-        else {
-            panic!("rampify emits procedural bricks");
-        };
-        let BrickType::Procedural {
-            asset: ramp_asset, ..
-        } = &ramp.asset
-        else {
-            panic!("rampify emits procedural bricks");
-        };
-        assert_eq!(wedge_asset.as_ref(), "PB_DefaultWedge");
-        assert_eq!(ramp_asset.as_ref(), "PB_DefaultRamp");
-    }
-
-    /// A ramp's footprint must land exactly on the cells it consumed, whichever
-    /// way it runs. Two of the four rotations run toward negative axes, which
-    /// is exactly where a centring mistake hides.
-    #[test]
-    fn a_ramp_is_centred_over_the_cells_it_covers() {
+    fn a_ramp_uses_the_right_asset_and_covers_its_own_cells() {
         let layout = layout();
         let full = layout.half * 2;
+        let color = Color::new(1, 2, 3);
+
+        assert_eq!(
+            asset(&ramp_brick(&layout, Cell(0, 0, 0), 1, 2, Rotation::Deg0, color)),
+            "PB_DefaultWedge"
+        );
+        assert_eq!(
+            asset(&ramp_brick(&layout, Cell(0, 0, 0), 3, 2, Rotation::Deg0, color)),
+            "PB_DefaultRamp"
+        );
+
         for (rotation, forward) in [
             (Rotation::Deg0, Cell(-1, 0, 0)),
             (Rotation::Deg90, Cell(0, -1, 0)),
             (Rotation::Deg180, Cell(1, 0, 0)),
             (Rotation::Deg270, Cell(0, 1, 0)),
         ] {
-            let anchor = Cell(4, 4, 0);
-            let run = 3;
-            let brick = ramp_brick(&layout, anchor, run, 2, rotation, Color::new(0, 0, 0));
+            let (anchor, run) = (Cell(4, 4, 0), 3);
+            let brick = ramp_brick(&layout, anchor, run, 2, rotation, color);
             let far = anchor + forward * (run - 1);
-            // Centre of the covered span, in units, cell centres included.
+            // The center of the cells that the ramp covers, in units.
             let expect_x = (anchor.0.min(far.0) * full + anchor.0.max(far.0) * full + full) / 2;
             let expect_y = (anchor.1.min(far.1) * full + anchor.1.max(far.1) * full + full) / 2;
             assert_eq!(
                 (brick.position.x, brick.position.y),
                 (expect_x, expect_y),
-                "{rotation:?} ramp is off its footprint"
+                "the ramp at {rotation:?} is not over its own cells"
             );
         }
     }

--- a/src/opt/rampify.rs
+++ b/src/opt/rampify.rs
@@ -490,6 +490,12 @@ pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
     if width == 0 || height == 0 {
         return Err("Heightmap is empty".to_string());
     }
+    // A zero cell size would make `layout.half` zero, which divides by zero in
+    // `fill_gaps` (`MAX_HALF_EXTENT / layout.half`) and would emit zero-extent
+    // bricks besides. Refuse it like the other invalid inputs above.
+    if options.size == 0 {
+        return Err("Brick size must be at least 1".to_string());
+    }
 
     // The rise of a ramp is a whole number of plates, so the vertical scale
     // must also be a whole number of plates.
@@ -1036,6 +1042,51 @@ mod tests {
                 (expect_x, expect_y),
                 "the ramp at {rotation:?} is not over its own cells"
             );
+        }
+    }
+
+    /// A zero brick size must be refused with an error, not a divide-by-zero
+    /// panic in `fill_gaps` (`MAX_HALF_EXTENT / layout.half`).
+    #[test]
+    fn a_zero_brick_size_is_refused_not_a_panic() {
+        struct Flat;
+        impl Heightmap for Flat {
+            fn at(&self, _x: u32, _y: u32) -> u32 {
+                2
+            }
+            fn size(&self) -> (u32, u32) {
+                (4, 4)
+            }
+        }
+        struct Grey;
+        impl Colormap for Grey {
+            fn at(&self, _x: u32, _y: u32) -> [u8; 4] {
+                [128, 128, 128, 255]
+            }
+            fn size(&self) -> (u32, u32) {
+                (4, 4)
+            }
+        }
+        let opts = GenOptions {
+            size: 0,
+            scale: 4,
+            asset: PB_DEFAULT_BRICK,
+            cull: false,
+            micro: false,
+            stud: false,
+            snap: false,
+            img: false,
+            glow: false,
+            hdmap: false,
+            lrgb: false,
+            nocollide: false,
+            quadtree: true,
+            greedy: false,
+            surface: SurfaceMode::Rampify,
+        };
+        match gen_rampify_heightmap(&Flat, &Grey, opts, |_| true) {
+            Err(e) => assert!(e.contains("size"), "unexpected error: {e}"),
+            Ok(_) => panic!("a zero brick size must be refused"),
         }
     }
 }

--- a/src/opt/rampify.rs
+++ b/src/opt/rampify.rs
@@ -1,0 +1,1046 @@
+//! Wrapperup's rampifier, over a heightmap's column field.
+//!
+//! The slope-selection algorithm is Wrapperup/rampifier's, by way of the
+//! BRDB-native port in `obj2brz` (`crates/obj2brz/src/rampify.rs`): scan the
+//! surface, fit the longest ramp that meets the terrain rising in front of it,
+//! prefer corner ramps at convex and concave turns, then fill whatever is left
+//! with plain bricks. The fitting rules, the run/rise limits and the brick
+//! geometry are all carried over unchanged.
+//!
+//! What is NOT carried over is the dense voxel grid. `obj2brz` rampifies an
+//! arbitrary mesh, so it materialises one cell per voxel of the bounding box
+//! and caps the model at 64M of them. A heightmap is a HEIGHT FIELD -- a column
+//! is solid from the ground to its top and empty above -- so occupancy is a
+//! comparison rather than a lookup, and a 4096x4096 map at 255 plates costs a
+//! `Vec<i32>` per column instead of the four terabytes its bounding box would
+//! ask for. Two consequences fall out of that and are relied on below:
+//!
+//! * **Only the top cell of a column can anchor a slope.** Both `fit_ramp` and
+//!   `fit_corner` refuse a cell with anything above it, so the whole
+//!   ascending-Z scan reduces to visiting each column once, in height order.
+//! * **There is no enclosed air and no underside.** The mesh rampifier floods
+//!   air to find the inside of a watertight model and fits upside-down ramps
+//!   under overhangs; a height field has neither, so only the floor pass runs.
+//!
+//! One voxel is one pixel wide (`GenOptions::size` half extents) and one plate
+//! tall (4 units). `--vertical` is read as units and rounded to a whole number
+//! of plates, because a `PB_DefaultRamp`'s rise is quantized to plates.
+
+use crate::map::*;
+use crate::util::*;
+use brdb::{
+    Brick, BrickSize, BrickType, Color, Direction, Position, Rotation,
+    assets::{
+        bricks::{
+            PB_DEFAULT_BRICK, PB_DEFAULT_RAMP, PB_DEFAULT_RAMP_CORNER,
+            PB_DEFAULT_RAMP_INNER_CORNER, PB_DEFAULT_WEDGE,
+        },
+        materials::{GLOW, PLASTIC},
+    },
+};
+use log::info;
+use std::collections::HashMap;
+
+/// Longest run a ramp may span, in cells. Wrapperup's value.
+const RAMP_MAX_RUN: i32 = 4;
+/// Tallest rise a ramp may span, in cells. Wrapperup's value.
+const RAMP_MAX_RISE: i32 = 12;
+/// Vertical units in one cell: a plate.
+const CELL_UNITS: i32 = 4;
+/// The largest half extent a procedural brick may carry.
+const MAX_HALF_EXTENT: i32 = 250;
+
+/// A cell coordinate. X and Y index the pixel grid; Z counts plates up from the
+/// ground.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct Cell(i32, i32, i32);
+
+impl std::ops::Add for Cell {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0, self.1 + rhs.1, self.2 + rhs.2)
+    }
+}
+
+impl std::ops::Sub for Cell {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0, self.1 - rhs.1, self.2 - rhs.2)
+    }
+}
+
+impl std::ops::Mul<i32> for Cell {
+    type Output = Self;
+    fn mul(self, rhs: i32) -> Self {
+        Self(self.0 * rhs, self.1 * rhs, self.2 * rhs)
+    }
+}
+
+impl Cell {
+    /// Which way a ramp of this rotation runs UPHILL. Rotation zero steps down
+    /// toward `+X`, so its uphill direction is `-X`; the rest are quarter turns
+    /// counter-clockwise around `+Z`.
+    fn forward(rotation: Rotation) -> Self {
+        match rotation {
+            Rotation::Deg0 => Self(-1, 0, 0),
+            Rotation::Deg90 => Self(0, -1, 0),
+            Rotation::Deg180 => Self(1, 0, 0),
+            Rotation::Deg270 => Self(0, 1, 0),
+        }
+    }
+}
+
+fn next_rotation(rotation: Rotation) -> Rotation {
+    match rotation {
+        Rotation::Deg0 => Rotation::Deg90,
+        Rotation::Deg90 => Rotation::Deg180,
+        Rotation::Deg180 => Rotation::Deg270,
+        Rotation::Deg270 => Rotation::Deg0,
+    }
+}
+
+/// The height field the rampifier reads, plus the cells already claimed by a
+/// slope.
+struct Field {
+    width: i32,
+    height: i32,
+    /// Solid cells in each column: the column occupies `0..cells`.
+    cells: Vec<i32>,
+    colors: Vec<[u8; 4]>,
+    /// Inclusive Z ranges consumed by an emitted slope, per column. A column
+    /// carries at most a handful, so a small `Vec` beats a per-cell bitmap by
+    /// orders of magnitude on a real map.
+    claimed: Vec<Vec<(i32, i32)>>,
+}
+
+impl Field {
+    fn index(&self, x: i32, y: i32) -> Option<usize> {
+        (x >= 0 && y >= 0 && x < self.width && y < self.height)
+            .then(|| y as usize * self.width as usize + x as usize)
+    }
+
+    fn column(&self, cell: Cell) -> i32 {
+        self.index(cell.0, cell.1).map_or(0, |i| self.cells[i])
+    }
+
+    fn exists(&self, cell: Cell) -> bool {
+        cell.2 >= 0 && cell.2 < self.column(cell)
+    }
+
+    fn is_ramp(&self, cell: Cell) -> bool {
+        self.index(cell.0, cell.1).is_some_and(|i| {
+            self.claimed[i]
+                .iter()
+                .any(|(low, high)| cell.2 >= *low && cell.2 <= *high)
+        })
+    }
+
+    /// How many cells of solid material sit at and above `cell`, capped at 31.
+    /// `i32::MIN` when the cell itself is air, so an empty neighbour can never
+    /// win the `max_by_key` in [`Self::best_rotation`].
+    fn slope_height(&self, cell: Cell) -> i32 {
+        if !self.exists(cell) {
+            return i32::MIN;
+        }
+        (self.column(cell) - cell.2).min(31)
+    }
+
+    /// The direction whose terrain rises highest in front of `cell` while the
+    /// cell BEHIND it is open, i.e. the way a ramp here should climb.
+    fn best_rotation(&self, cell: Cell) -> Option<Rotation> {
+        if self.exists(cell + Cell(0, 0, 1)) {
+            return None;
+        }
+        [
+            (Cell(-1, 0, 0), Cell(1, 0, 0), Rotation::Deg0),
+            (Cell(1, 0, 0), Cell(-1, 0, 0), Rotation::Deg180),
+            (Cell(0, -1, 0), Cell(0, 1, 0), Rotation::Deg90),
+            (Cell(0, 1, 0), Cell(0, -1, 0), Rotation::Deg270),
+        ]
+        .into_iter()
+        .filter(|(_, back, _)| !self.exists(cell + *back))
+        .map(|(forward, _, rotation)| (self.slope_height(cell + forward), rotation))
+        .max_by_key(|(height, _)| *height)
+        .and_then(|(height, rotation)| (height > 0).then_some(rotation))
+    }
+
+    /// The run and rise of the straight ramp anchored at `cell` climbing
+    /// `rotation`, or `None` where no ramp fits.
+    fn fit_ramp(&self, cell: Cell, rotation: Rotation) -> Option<(i32, i32)> {
+        let forward = Cell::forward(rotation);
+        let up = Cell(0, 0, 1);
+
+        let mut run = 0;
+        for _ in 0..RAMP_MAX_RUN - 1 {
+            if !self.exists(cell + up + forward * run)
+                && self.exists(cell + forward * (run + 1))
+                && !self.is_ramp(cell + forward * (run + 1))
+            {
+                run += 1;
+            } else {
+                break;
+            }
+        }
+        if run == 0 {
+            return None;
+        }
+
+        let mut rise = 0;
+        for _ in 1..RAMP_MAX_RISE {
+            let tip = cell + up * rise + forward * run;
+            if self.exists(tip) && !self.is_ramp(tip) {
+                rise += 1;
+            } else {
+                break;
+            }
+        }
+        // A summit the ramp runs off the far side of gets one more cell of
+        // rise, so a ridge is capped rather than left a plate short.
+        let mut add_one = 0;
+        for step in 1..RAMP_MAX_RUN {
+            let beyond = cell + up * rise + forward * (run + step);
+            if !self.exists(beyond) && !self.is_ramp(beyond) {
+                add_one = 1;
+            } else {
+                add_one = 0;
+                break;
+            }
+        }
+        rise += add_one;
+        (rise > 1).then_some((run + 1, rise - 1))
+    }
+
+    /// The runs along each wall axis and the rise of a corner ramp whose two
+    /// high walls face `rotation` and `rotation + 90`, with `cell` as the low
+    /// outer corner.
+    ///
+    /// An OUTER corner (a convex contour turn) has open cells behind both wall
+    /// axes and rising terrain only past the far diagonal. An INNER corner (a
+    /// concave turn) sits where the edge wraps the other way: the cells behind
+    /// it are still edge, only the diagonal between them is open, and the
+    /// terrain rises along the whole far row and column.
+    fn fit_corner(&self, cell: Cell, rotation: Rotation, inner: bool) -> Option<(i32, i32, i32)> {
+        let up = Cell(0, 0, 1);
+        let forward_a = Cell::forward(rotation);
+        let forward_b = Cell::forward(next_rotation(rotation));
+        if self.exists(cell + up) {
+            return None;
+        }
+        let corner_shaped = if inner {
+            self.exists(cell - forward_a)
+                && self.exists(cell - forward_b)
+                && !self.exists(cell - forward_a - forward_b)
+        } else {
+            !self.exists(cell - forward_a) && !self.exists(cell - forward_b)
+        };
+        if !corner_shaped {
+            return None;
+        }
+        let (run_a, rise_a) = self.fit_ramp(cell, rotation)?;
+        let (run_b, rise_b) = self.fit_ramp(cell, next_rotation(rotation))?;
+        // The two edge fits rarely agree exactly on rough terrain; the lower
+        // rise still meets both neighbouring slopes.
+        let rise = rise_a.min(rise_b);
+
+        // An outer corner's surface is the INTERSECTION of the two straight
+        // ramps, so it only reaches full height at the far diagonal cell; an
+        // inner corner's is their UNION and is full height along the whole far
+        // row and column. Those cells may hold the rising terrain; everywhere
+        // else the footprint must be flat with air above it.
+        let clear = |cells_a: i32, cells_b: i32| {
+            for i in 0..cells_a {
+                for j in 0..cells_b {
+                    let footprint = cell + forward_a * i + forward_b * j;
+                    if !self.exists(footprint) || self.is_ramp(footprint) {
+                        return false;
+                    }
+                    let on_far_a = i == cells_a - 1;
+                    let on_far_b = j == cells_b - 1;
+                    let full_height = if inner {
+                        on_far_a || on_far_b
+                    } else {
+                        on_far_a && on_far_b
+                    };
+                    if !full_height && self.exists(footprint + up) {
+                        return false;
+                    }
+                }
+            }
+            true
+        };
+        // The full-run footprint is often obstructed on rough terrain, so fall
+        // back to the largest clear rectangle that still makes a corner (2x2).
+        let mut best: Option<(i32, i32)> = None;
+        for cells_a in 2..=run_a {
+            for cells_b in 2..=run_b {
+                if best.is_none_or(|(a, b)| cells_a * cells_b > a * b) && clear(cells_a, cells_b) {
+                    best = Some((cells_a, cells_b));
+                }
+            }
+        }
+        best.map(|(cells_a, cells_b)| (cells_a, cells_b, rise))
+    }
+
+    /// Claim every cell in a box and report the colour that dominates the solid
+    /// ones. A slope covers several columns, and taking the anchor's colour
+    /// instead would tint every ramp with the colour of its lowest pixel.
+    fn claim(&mut self, origin: Cell, axes: [(Cell, i32); 2], rise: i32) -> Color {
+        let mut counts = HashMap::<[u8; 4], usize>::new();
+        for i in 0..axes[0].1 {
+            for j in 0..axes[1].1 {
+                let base = origin + axes[0].0 * i + axes[1].0 * j;
+                let Some(index) = self.index(base.0, base.1) else {
+                    continue;
+                };
+                let low = base.2;
+                let high = base.2 + rise - 1;
+                self.claimed[index].push((low, high));
+                let solid = self.cells[index].min(high + 1) - low;
+                if solid > 0 {
+                    *counts.entry(self.colors[index]).or_default() += solid as usize;
+                }
+            }
+        }
+        let rgba = counts
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .map(|(color, _)| color)
+            .unwrap_or([0, 0, 0, 255]);
+        Color {
+            r: rgba[0],
+            g: rgba[1],
+            b: rgba[2],
+        }
+    }
+}
+
+/// Where the rampifier's cell grid sits in world units, and how bricks are
+/// styled. Split out so the geometry can be exercised without a `GenOptions`.
+struct Layout {
+    /// Half extent of one cell in X and Y, in units.
+    half: i32,
+    offset_x: i32,
+    offset_y: i32,
+    /// World Z of the bottom of cell layer zero.
+    z_floor: i32,
+    glow: bool,
+    collision: brdb::Collision,
+}
+
+impl Layout {
+    fn brick(
+        &self,
+        asset: brdb::BString,
+        size: BrickSize,
+        position: Position,
+        color: Color,
+        rotation: Rotation,
+    ) -> Brick {
+        Brick {
+            asset: BrickType::Procedural { asset, size },
+            position,
+            collision: self.collision,
+            color,
+            owner_index: None,
+            direction: Direction::ZPositive,
+            rotation,
+            material_intensity: if self.glow { 0 } else { 5 },
+            material: if self.glow { GLOW } else { PLASTIC },
+            ..Default::default()
+        }
+    }
+}
+
+/// Emit a straight ramp (or a one-cell wedge) anchored at `cell`.
+///
+/// The anchor is the ramp's LOW end and the piece extends `run` cells along the
+/// rotation's forward axis, which for two of the four rotations runs toward
+/// NEGATIVE X or Y. The per-rotation offsets below place the brick's centre
+/// accordingly; they are the ported `create_ramp` offsets with `obj2brz`'s
+/// hard-coded stud (5 units half, 10 full) generalised to `Layout::half`.
+fn ramp_brick(
+    layout: &Layout,
+    cell: Cell,
+    run: i32,
+    rise: i32,
+    rotation: Rotation,
+    color: Color,
+) -> Brick {
+    let size = BrickSize::new(
+        (run * layout.half) as u16,
+        layout.half as u16,
+        (rise * 2) as u16,
+    );
+    let full = layout.half * 2;
+    let mut position = Position::new(
+        cell.0 * full + layout.offset_x,
+        cell.1 * full + layout.offset_y,
+        layout.z_floor + cell.2 * CELL_UNITS,
+    );
+    match rotation {
+        Rotation::Deg0 => {
+            position.x += full - size.x as i32;
+            position.y += size.y as i32;
+        }
+        Rotation::Deg90 => {
+            position.x += size.y as i32;
+            position.y += full - size.x as i32;
+        }
+        Rotation::Deg180 => {
+            position.x += size.x as i32;
+            position.y += size.y as i32;
+        }
+        Rotation::Deg270 => {
+            position.x += size.y as i32;
+            position.y += size.x as i32;
+        }
+    }
+    position.z += size.z as i32;
+    layout.brick(
+        // A single-cell run has no ramp asset; the wedge is its one-cell form.
+        if run < 2 {
+            PB_DEFAULT_WEDGE
+        } else {
+            PB_DEFAULT_RAMP
+        },
+        size,
+        position,
+        color,
+        rotation,
+    )
+}
+
+/// Emit a corner ramp anchored at its low outer corner.
+fn corner_brick(
+    layout: &Layout,
+    cell: Cell,
+    (run_a, run_b, rise): (i32, i32, i32),
+    inner: bool,
+    rotation: Rotation,
+    color: Color,
+) -> Brick {
+    let forward_a = Cell::forward(rotation);
+    let forward_b = Cell::forward(next_rotation(rotation));
+    let far = cell + forward_a * (run_a - 1) + forward_b * (run_b - 1);
+    // Local X follows the first wall axis, so a quarter turn swaps which run
+    // spans world X.
+    let (x_cells, y_cells) = if forward_a.0 != 0 {
+        (run_a, run_b)
+    } else {
+        (run_b, run_a)
+    };
+    let size = BrickSize::new(
+        (run_a * layout.half) as u16,
+        (run_b * layout.half) as u16,
+        (rise * 2) as u16,
+    );
+    let full = layout.half * 2;
+    let position = Position::new(
+        cell.0.min(far.0) * full + x_cells * layout.half + layout.offset_x,
+        cell.1.min(far.1) * full + y_cells * layout.half + layout.offset_y,
+        layout.z_floor + cell.2 * CELL_UNITS + size.z as i32,
+    );
+    layout.brick(
+        if inner {
+            PB_DEFAULT_RAMP_INNER_CORNER
+        } else {
+            PB_DEFAULT_RAMP_CORNER
+        },
+        size,
+        position,
+        color,
+        rotation,
+    )
+}
+
+/// Generate a rampified heightmap: full-size ramps, wedges and ramp corners
+/// fitted onto the column field's surface, with plain bricks under and beside
+/// them.
+pub fn gen_rampify_heightmap<F: Fn(f32) -> bool>(
+    heightmap: &dyn Heightmap,
+    colormap: &dyn Colormap,
+    options: GenOptions,
+    progress_f: F,
+) -> Result<Vec<Brick>, String> {
+    macro_rules! progress {
+        ($e:expr) => {
+            if !progress_f($e) {
+                return Err("Stopped by user".to_string());
+            }
+        };
+    }
+    progress!(0.0);
+
+    let (width, height) = heightmap.size();
+    if colormap.size() != (width, height) {
+        return Err("Heightmap and colormap must have same dimensions".to_string());
+    }
+    if width == 0 || height == 0 {
+        return Err("Heightmap is empty".to_string());
+    }
+
+    // A ramp's rise is quantized to plates, so the vertical scale is too.
+    let plates_per_shade = ((options.scale as i32 + CELL_UNITS / 2) / CELL_UNITS).max(1);
+    let effective = plates_per_shade * CELL_UNITS;
+    if effective != options.scale as i32 {
+        info!(
+            "Rampified terrain rises {effective} unit(s) per shade (--vertical {}, rounded to \
+             {plates_per_shade} plate(s): a ramp's rise is quantized to plates)",
+            options.scale
+        );
+    }
+
+    info!("Reading height columns");
+    let count = width as usize * height as usize;
+    let mut field = Field {
+        width: width as i32,
+        height: height as i32,
+        cells: vec![0; count],
+        colors: vec![[0, 0, 0, 255]; count],
+        claimed: vec![Vec::new(); count],
+    };
+    for y in 0..height {
+        for x in 0..width {
+            let index = y as usize * width as usize + x as usize;
+            let color = colormap.at(x, y);
+            let shade = heightmap.at(x, y).min(i32::MAX as u32) as i32;
+            field.colors[index] = color;
+            field.cells[index] = if options.cull && (shade == 0 || color[3] == 0) {
+                0
+            } else {
+                // `+ 1` so a black pixel is still one plate of ground rather
+                // than a hole, matching the minimum slab the blocky modes emit.
+                (shade.saturating_mul(plates_per_shade)).saturating_add(1)
+            };
+        }
+    }
+    progress!(0.15);
+
+    let layout = Layout {
+        half: options.size as i32,
+        offset_x: -(width as i32 * options.size as i32),
+        offset_y: -(height as i32 * options.size as i32),
+        // A one-plate column's TOP lands where the blocky modes put the top of
+        // a zero-height cell, so the two modes share a ground plane.
+        z_floor: options.base_height() - 5 - CELL_UNITS,
+        glow: options.glow,
+        collision: options.collision(),
+    };
+
+    // The full ascending-Z scan of the mesh rampifier, reduced to its only
+    // productive cells: `fit_ramp` and `fit_corner` both refuse a cell with
+    // anything above it, so on a height field the sole candidate per column is
+    // its top. Sorting by (height, y, x) visits them in exactly the order the
+    // z/y/x loop nest would have.
+    let mut anchors: Vec<u32> = (0..count as u32)
+        .filter(|i| field.cells[*i as usize] > 0)
+        .collect();
+    anchors.sort_unstable_by_key(|i| {
+        let i = *i as usize;
+        (field.cells[i], i)
+    });
+
+    let mut bricks = Vec::new();
+    let mut ramps = 0usize;
+    let mut corners = 0usize;
+
+    // Corners run first: a straight ramp along either edge next to a convex
+    // corner would otherwise consume the corner's own footprint.
+    info!("Fitting corner ramps");
+    for (n, index) in anchors.iter().enumerate() {
+        let index = *index as usize;
+        let cell = Cell(
+            (index % width as usize) as i32,
+            (index / width as usize) as i32,
+            field.cells[index] - 1,
+        );
+        if field.is_ramp(cell) {
+            continue;
+        }
+        'placed: for rotation in [
+            Rotation::Deg0,
+            Rotation::Deg90,
+            Rotation::Deg180,
+            Rotation::Deg270,
+        ] {
+            for inner in [false, true] {
+                if let Some(fit) = field.fit_corner(cell, rotation, inner) {
+                    let (run_a, run_b, rise) = fit;
+                    let color = field.claim(
+                        cell,
+                        [
+                            (Cell::forward(rotation), run_a),
+                            (Cell::forward(next_rotation(rotation)), run_b),
+                        ],
+                        rise,
+                    );
+                    bricks.push(corner_brick(&layout, cell, fit, inner, rotation, color));
+                    corners += 1;
+                    break 'placed;
+                }
+            }
+        }
+        if n % 4096 == 0 {
+            progress!(0.15 + 0.3 * (n as f32 / anchors.len().max(1) as f32));
+        }
+    }
+    progress!(0.45);
+
+    info!("Fitting ramps");
+    for (n, index) in anchors.iter().enumerate() {
+        let index = *index as usize;
+        let cell = Cell(
+            (index % width as usize) as i32,
+            (index / width as usize) as i32,
+            field.cells[index] - 1,
+        );
+        if field.is_ramp(cell) {
+            continue;
+        }
+        let Some(rotation) = field.best_rotation(cell) else {
+            continue;
+        };
+        let Some((run, rise)) = field.fit_ramp(cell, rotation) else {
+            continue;
+        };
+        let color = field.claim(
+            cell,
+            [(Cell::forward(rotation), run), (Cell(0, 0, 0), 1)],
+            rise,
+        );
+        bricks.push(ramp_brick(&layout, cell, run, rise, rotation, color));
+        ramps += 1;
+        if n % 4096 == 0 {
+            progress!(0.45 + 0.3 * (n as f32 / anchors.len().max(1) as f32));
+        }
+    }
+    progress!(0.75);
+
+    info!("Filling gaps");
+    let fills = fill_gaps(&field, &layout, &mut bricks, &progress_f)?;
+
+    info!(
+        "Rampified {} pixel(s) into {} brick(s): {corners} corner ramp(s), {ramps} ramp(s), \
+         {fills} block(s)",
+        count,
+        bricks.len(),
+    );
+    progress!(1.0);
+    Ok(bricks)
+}
+
+/// Fill everything the slopes did not claim with plain bricks, merging equal
+/// spans across neighbouring columns.
+///
+/// The mesh rampifier grows a box cell by cell because its colours vary in Z.
+/// A height field's colour is a property of the COLUMN, so what is left of a
+/// column after the slopes is a handful of Z spans, and two neighbouring
+/// columns merge exactly when a span and a colour both match. That turns the
+/// per-cell growth into one pass over spans.
+fn fill_gaps<F: Fn(f32) -> bool>(
+    field: &Field,
+    layout: &Layout,
+    out: &mut Vec<Brick>,
+    progress_f: &F,
+) -> Result<usize, String> {
+    let count = field.cells.len();
+    let mut spans: Vec<Vec<(i32, i32)>> = Vec::with_capacity(count);
+    for index in 0..count {
+        spans.push(unclaimed_spans(field, index));
+    }
+    let mut taken: Vec<Vec<bool>> = spans.iter().map(|s| vec![false; s.len()]).collect();
+
+    // A brick may not exceed 500 units on any axis.
+    let max_run = (MAX_HALF_EXTENT / layout.half).max(1);
+    let mut emitted = 0usize;
+
+    // A neighbouring column joins this box only when it offers the SAME span,
+    // still unclaimed, under the same colour. Spans within one column are
+    // disjoint, so at most one can match.
+    let matching =
+        |index: usize, span: (i32, i32), color: [u8; 4], taken: &[Vec<bool>]| -> Option<usize> {
+            if field.colors[index] != color {
+                return None;
+            }
+            spans[index]
+                .iter()
+                .position(|s| *s == span)
+                .filter(|k| !taken[index][*k])
+        };
+
+    for y in 0..field.height {
+        for x in 0..field.width {
+            let index = y as usize * field.width as usize + x as usize;
+            for k in 0..spans[index].len() {
+                if taken[index][k] {
+                    continue;
+                }
+                let span = spans[index][k];
+                let color = field.colors[index];
+                let mut claimed = vec![(index, k)];
+
+                let mut run_x = 1;
+                while run_x < max_run && x + run_x < field.width {
+                    let neighbour = index + run_x as usize;
+                    match matching(neighbour, span, color, &taken) {
+                        Some(j) => {
+                            claimed.push((neighbour, j));
+                            run_x += 1;
+                        }
+                        None => break,
+                    }
+                }
+
+                let mut run_y = 1;
+                'rows: while run_y < max_run && y + run_y < field.height {
+                    let mut row = Vec::with_capacity(run_x as usize);
+                    for dx in 0..run_x {
+                        let neighbour =
+                            index + (run_y as usize * field.width as usize) + dx as usize;
+                        match matching(neighbour, span, color, &taken) {
+                            Some(j) => row.push((neighbour, j)),
+                            // A partial row is discarded whole: the box has to
+                            // stay rectangular.
+                            None => break 'rows,
+                        }
+                    }
+                    claimed.extend(row);
+                    run_y += 1;
+                }
+
+                for (i, j) in claimed {
+                    taken[i][j] = true;
+                }
+
+                let plates = span.1 - span.0 + 1;
+                let size = BrickSize::new(
+                    (run_x * layout.half) as u16,
+                    (run_y * layout.half) as u16,
+                    (plates * 2) as u16,
+                );
+                let full = layout.half * 2;
+                out.push(layout.brick(
+                    PB_DEFAULT_BRICK,
+                    size,
+                    Position::new(
+                        x * full + size.x as i32 + layout.offset_x,
+                        y * full + size.y as i32 + layout.offset_y,
+                        layout.z_floor + span.0 * CELL_UNITS + size.z as i32,
+                    ),
+                    Color {
+                        r: color[0],
+                        g: color[1],
+                        b: color[2],
+                    },
+                    Rotation::Deg0,
+                ));
+                emitted += 1;
+            }
+        }
+        if y % 64 == 0 && !progress_f(0.75 + 0.2 * (y as f32 / field.height.max(1) as f32)) {
+            return Err("Stopped by user".to_string());
+        }
+    }
+    Ok(emitted)
+}
+
+/// One column's solid Z spans minus everything a slope claimed, split so no
+/// span exceeds the tallest brick the format can carry.
+fn unclaimed_spans(field: &Field, index: usize) -> Vec<(i32, i32)> {
+    let top = field.cells[index];
+    if top <= 0 {
+        return Vec::new();
+    }
+    let mut claimed = field.claimed[index].clone();
+    claimed.sort_unstable();
+
+    let mut spans = Vec::new();
+    let mut z = 0;
+    for (low, high) in claimed {
+        let low = low.max(0);
+        let high = high.min(top - 1);
+        if high < low {
+            continue;
+        }
+        if low > z {
+            spans.push((z, low - 1));
+        }
+        z = z.max(high + 1);
+    }
+    if z < top {
+        spans.push((z, top - 1));
+    }
+
+    let max_plates = MAX_HALF_EXTENT / 2;
+    let mut split = Vec::with_capacity(spans.len());
+    for (low, high) in spans {
+        let mut low = low;
+        while low <= high {
+            let end = (low + max_plates - 1).min(high);
+            split.push((low, end));
+            low = end + 1;
+        }
+    }
+    split
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A field built from a closure over `(x, y)` giving each column's plate
+    /// count, all one colour.
+    fn field(width: i32, height: i32, column: impl Fn(i32, i32) -> i32) -> Field {
+        let count = (width * height) as usize;
+        let mut cells = vec![0; count];
+        for y in 0..height {
+            for x in 0..width {
+                cells[(y * width + x) as usize] = column(x, y);
+            }
+        }
+        Field {
+            width,
+            height,
+            cells,
+            colors: vec![[9, 8, 7, 255]; count],
+            claimed: vec![Vec::new(); count],
+        }
+    }
+
+    fn layout() -> Layout {
+        Layout {
+            half: 5,
+            offset_x: 0,
+            offset_y: 0,
+            z_floor: 0,
+            glow: false,
+            collision: brdb::Collision::default(),
+        }
+    }
+
+    /// `brdb::Rotation` carries no `PartialEq`, so assertions compare quarter
+    /// turns instead.
+    fn turn(rotation: Option<Rotation>) -> Option<u8> {
+        rotation.map(|r| match r {
+            Rotation::Deg0 => 0,
+            Rotation::Deg90 => 1,
+            Rotation::Deg180 => 2,
+            Rotation::Deg270 => 3,
+        })
+    }
+
+    fn top(field: &Field, x: i32, y: i32) -> Cell {
+        Cell(x, y, field.cells[(y * field.width + x) as usize] - 1)
+    }
+
+    /// The rampifier's whole premise: a staircase becomes a slope. A ramp must
+    /// fit at the foot of a rising run, and it must climb toward the rise.
+    #[test]
+    fn a_rising_staircase_fits_a_ramp_climbing_it() {
+        // Columns get taller with +X, so the uphill direction is +X: rotation
+        // 180, whose forward is (1, 0, 0).
+        let field = field(8, 3, |x, _| 1 + x);
+        let anchor = top(&field, 0, 1);
+        assert_eq!(turn(field.best_rotation(anchor)), Some(2));
+        let (run, rise) = field
+            .fit_ramp(anchor, Rotation::Deg180)
+            .expect("a ramp fits at the foot of a staircase");
+        assert!(run >= 2 && rise >= 1, "got run {run}, rise {rise}");
+    }
+
+    /// A cell with material above it can never anchor a slope. This is what
+    /// licenses visiting one anchor per column instead of scanning every Z.
+    #[test]
+    fn only_the_top_cell_of_a_column_can_anchor_a_slope() {
+        let field = field(8, 3, |x, _| 1 + x);
+        let buried = Cell(3, 1, 0);
+        assert!(
+            field.exists(buried + Cell(0, 0, 1)),
+            "the test cell must be buried"
+        );
+        assert_eq!(turn(field.best_rotation(buried)), None);
+        assert_eq!(field.fit_corner(buried, Rotation::Deg0, false), None);
+        assert_eq!(field.fit_corner(buried, Rotation::Deg0, true), None);
+    }
+
+    /// Inside a flat plain there is nothing to climb, so no cell may slope.
+    ///
+    /// The RIM is deliberately excluded: a column at the map's edge has open
+    /// air behind it and material in front, which is a one-plate step, and the
+    /// rampifier bevels it exactly as the mesh version bevels the edge of a
+    /// slab. That is a property of the edge, not of the plain.
+    #[test]
+    fn the_interior_of_a_flat_plain_fits_no_ramp_at_all() {
+        let field = field(8, 8, |_, _| 3);
+        for y in 1..7 {
+            for x in 1..7 {
+                assert_eq!(
+                    turn(field.best_rotation(top(&field, x, y))),
+                    None,
+                    "({x}, {y}) is surrounded by its own height and must not slope"
+                );
+            }
+        }
+        // ...and the rim really does bevel, so the exclusion above is a
+        // statement about this renderer rather than a hole in the test.
+        assert!(turn(field.best_rotation(top(&field, 0, 4))).is_some());
+    }
+
+    /// A convex plateau turn is what the corner asset exists for; a straight
+    /// edge must never match one, or corners would eat the whole ridge.
+    #[test]
+    fn a_convex_plateau_turn_fits_a_corner_and_a_straight_edge_does_not() {
+        // A 12x12 plain with a raised quadrant, so the plateau's outer corner
+        // is a convex turn and its edges are straight. The anchor is the
+        // plateau's own corner cell -- a corner ramp BEVELS the turn it sits
+        // on, it does not sit on the ground beside it.
+        let field = field(12, 12, |x, y| if x >= 6 && y >= 6 { 4 } else { 1 });
+        let corner = top(&field, 6, 6);
+        let fits = [
+            Rotation::Deg0,
+            Rotation::Deg90,
+            Rotation::Deg180,
+            Rotation::Deg270,
+        ]
+        .into_iter()
+        .any(|r| field.fit_corner(corner, r, false).is_some());
+        assert!(
+            fits,
+            "the convex plateau corner must fit an outer corner ramp"
+        );
+
+        let straight = top(&field, 6, 9);
+        let straight_fits = [
+            Rotation::Deg0,
+            Rotation::Deg90,
+            Rotation::Deg180,
+            Rotation::Deg270,
+        ]
+        .into_iter()
+        .any(|r| field.fit_corner(straight, r, false).is_some());
+        assert!(
+            !straight_fits,
+            "a straight plateau edge must be a plain ramp, not a corner"
+        );
+    }
+
+    /// Claiming a slope's cells must remove them from the fill pass, or every
+    /// ramp would be buried inside the blocks meant to sit under it.
+    #[test]
+    fn claimed_cells_do_not_come_back_as_fill_blocks() {
+        let mut field = field(8, 3, |x, _| 1 + x);
+        let anchor = top(&field, 0, 1);
+        let (run, rise) = field.fit_ramp(anchor, Rotation::Deg180).unwrap();
+        field.claim(
+            anchor,
+            [(Cell::forward(Rotation::Deg180), run), (Cell(0, 0, 0), 1)],
+            rise,
+        );
+
+        let index = (1 * field.width + anchor.0) as usize;
+        assert!(field.is_ramp(anchor));
+        let spans = unclaimed_spans(&field, index);
+        assert!(
+            spans
+                .iter()
+                .all(|(low, high)| anchor.2 < *low || anchor.2 > *high),
+            "the anchor cell is still offered to the fill pass: {spans:?}"
+        );
+    }
+
+    #[test]
+    fn a_tall_column_is_split_into_legal_bricks() {
+        let field = field(1, 1, |_, _| 1000);
+        let spans = unclaimed_spans(&field, 0);
+        assert!(spans.len() > 1, "a 1000-plate column must be split");
+        for (low, high) in &spans {
+            assert!(
+                (high - low + 1) * 2 <= MAX_HALF_EXTENT,
+                "span {low}..={high} exceeds the largest legal brick"
+            );
+        }
+        // No gaps and no overlap: the splits must still tile the column.
+        assert_eq!(spans[0].0, 0);
+        assert_eq!(spans.last().unwrap().1, 999);
+        for pair in spans.windows(2) {
+            assert_eq!(pair[0].1 + 1, pair[1].0);
+        }
+    }
+
+    /// A flat plain must merge into a few big blocks rather than one per pixel.
+    #[test]
+    fn the_fill_pass_merges_equal_columns_into_boxes() {
+        let field = field(16, 16, |_, _| 2);
+        let mut bricks = Vec::new();
+        let filled = fill_gaps(&field, &layout(), &mut bricks, &|_| true).unwrap();
+        assert_eq!(filled, bricks.len());
+        assert!(
+            bricks.len() < 32,
+            "256 identical columns collapsed to only {} brick(s)",
+            bricks.len()
+        );
+    }
+
+    /// One-cell runs have no ramp asset; the wedge is the one-cell ramp.
+    #[test]
+    fn a_single_cell_run_uses_the_wedge_asset() {
+        let wedge = ramp_brick(
+            &layout(),
+            Cell(0, 0, 0),
+            1,
+            2,
+            Rotation::Deg0,
+            Color::new(1, 2, 3),
+        );
+        let ramp = ramp_brick(
+            &layout(),
+            Cell(0, 0, 0),
+            3,
+            2,
+            Rotation::Deg0,
+            Color::new(1, 2, 3),
+        );
+        let BrickType::Procedural {
+            asset: wedge_asset, ..
+        } = &wedge.asset
+        else {
+            panic!("rampify emits procedural bricks");
+        };
+        let BrickType::Procedural {
+            asset: ramp_asset, ..
+        } = &ramp.asset
+        else {
+            panic!("rampify emits procedural bricks");
+        };
+        assert_eq!(wedge_asset.as_ref(), "PB_DefaultWedge");
+        assert_eq!(ramp_asset.as_ref(), "PB_DefaultRamp");
+    }
+
+    /// A ramp's footprint must land exactly on the cells it consumed, whichever
+    /// way it runs. Two of the four rotations run toward negative axes, which
+    /// is exactly where a centring mistake hides.
+    #[test]
+    fn a_ramp_is_centred_over_the_cells_it_covers() {
+        let layout = layout();
+        let full = layout.half * 2;
+        for (rotation, forward) in [
+            (Rotation::Deg0, Cell(-1, 0, 0)),
+            (Rotation::Deg90, Cell(0, -1, 0)),
+            (Rotation::Deg180, Cell(1, 0, 0)),
+            (Rotation::Deg270, Cell(0, 1, 0)),
+        ] {
+            let anchor = Cell(4, 4, 0);
+            let run = 3;
+            let brick = ramp_brick(&layout, anchor, run, 2, rotation, Color::new(0, 0, 0));
+            let far = anchor + forward * (run - 1);
+            // Centre of the covered span, in units, cell centres included.
+            let expect_x = (anchor.0.min(far.0) * full + anchor.0.max(far.0) * full + full) / 2;
+            let expect_y = (anchor.1.min(far.1) * full + anchor.1.max(far.1) * full + full) / 2;
+            assert_eq!(
+                (brick.position.x, brick.position.y),
+                (expect_x, expect_y),
+                "{rotation:?} ramp is off its footprint"
+            );
+        }
+    }
+}

--- a/src/opt/terrain.rs
+++ b/src/opt/terrain.rs
@@ -1,52 +1,50 @@
-//! Smooth micro-brick terrain.
+//! Smooth terrain from micro bricks.
 //!
-//! The blocky renderers ([`super::gen_quad_heightmap`],
-//! [`super::gen_greedy_heightmap`]) give every pixel a flat top, so a slope
-//! comes out as a staircase. This one gives every pixel a SLOPED top, chosen
-//! from Brickadia's micro wedge family, so a smooth height field renders as a
+//! The other renderers give each pixel a flat top, so a slope becomes a
+//! staircase. This renderer gives each pixel a SLOPED top. It selects that top
+//! from the Brickadia micro wedge family. A smooth height field then becomes a
 //! smooth surface.
 //!
-//! The geometry contract is the measured one from the `terrain-experiment`
-//! prefab generator (`docs/MICRO_TERRAIN_GEOMETRY.md`), derived by correlating
-//! an in-game GLB export against the same ordered `.brz` through BRDB. The
-//! facts this module depends on, restated so it can be read on its own:
+//! The geometry rules come from the `terrain-experiment` prefab generator
+//! (`docs/MICRO_TERRAIN_GEOMETRY.md`). They are measured values: a GLB export
+//! from the game was compared with the same `.brz` file read through BRDB.
+//! This module uses these rules:
 //!
-//! * Brickadia stores 10 position units per stud, and a procedural brick's
-//!   `BrickSize` components are HALF extents. A shape with `z = k` is `2k`
-//!   units tall, so any rise this module emits must be even.
-//! * Heights are sampled on a SHARED VERTEX grid, not per pixel. Two
-//!   neighbouring cells quote the same vertex, which is what makes their
-//!   surfaces meet instead of merely coming close.
-//! * With `Direction::ZPositive` and `Rotation::Deg0`, and corners read in
-//!   `(SW, SE, NE, NW)` order (i.e. `(-X,-Y)`, `(+X,-Y)`, `(+X,+Y)`,
-//!   `(-X,+Y)`):
+//! * Brickadia uses 10 position units for one stud. The `BrickSize` values of
+//!   a procedural brick are HALF extents. A shape with `z = k` is `2k` units
+//!   high, so each rise must be an even number of units.
+//! * The heights come from a grid of SHARED vertices, not from each pixel. Two
+//!   adjacent cells use the same vertex, so their surfaces touch exactly.
+//! * The table below applies at `Direction::ZPositive` and `Rotation::Deg0`.
+//!   Read the corners in the sequence `(SW, SE, NE, NW)`. That sequence is
+//!   `(-X,-Y)`, `(+X,-Y)`, `(+X,+Y)`, `(-X,+Y)`.
 //!
 //!   | asset | surface |
 //!   | --- | --- |
 //!   | `PB_DefaultMicroBrick` | `(1,1,1,1)`, flat top |
-//!   | `PB_DefaultMicroRamp` | low toward `+X` |
+//!   | `PB_DefaultMicroRamp` | low at `+X` |
 //!   | `PB_DefaultMicroWedgeCorner` | high vertex at SW |
 //!   | `PB_DefaultMicroWedgeInnerCorner` | low vertex at NE |
 //!   | `PB_DefaultMicroWedgeOuterCorner` | low vertex at NE |
 //!   | `PB_DefaultMicroWedgeTriangleCorner` | SW triangle, high at SW |
 //!
-//! * A flat micro brick is centred at `base - half_height`, so its TOP is at
-//!   `base`. A sloped shape is centred at `base + half_rise`, so its low
-//!   vertices are at `base` and its high ones at `base + rise`.
+//! * The center of a flat micro brick is at `base - half_height`, so its top
+//!   is at `base`. The center of a sloped shape is at `base + half_rise`. Its
+//!   low vertices are then at `base` and its high vertices at `base + rise`.
 //!
-//! **Every cell goes through the same best-fit selection.** `terrain-experiment`
-//! reserved that for "wall cells" and used a plain pattern match elsewhere;
-//! here it is the only path, because a heightmap is not a slope-limited field.
-//! A cliff, a one-pixel spike and a gentle dune all arrive as four corner
-//! altitudes, and the fit enumerates every assembly the grammar can express,
-//! scores each by its total deviation from those four, and takes the best.
+//! EACH cell uses the same best-fit selection. `terrain-experiment` uses that
+//! selection for "wall cells" only and uses a simple match for the other
+//! cells. This module has one path, because a heightmap has no slope limit. A
+//! cliff, a spike of one pixel and a smooth dune all supply four corner
+//! heights. The fit examines each shape that the rules permit. It gives each
+//! shape a score from the difference to those four heights, then keeps the
+//! best shape.
 //!
-//! Candidates are always fitted FROM BELOW -- each partition takes the MINIMUM
-//! of the corners it covers, never their mean -- so the chosen surface sits at
-//! or below every sampled vertex and can never protrude through the
-//! neighbouring tile. A clean two-level fault therefore becomes one exact steep
-//! ramp meeting the plain and the plateau flush, rather than a shelf stuck onto
-//! the cliff.
+//! The fit always stays BELOW the sample. Each candidate uses the MINIMUM of
+//! the corners that it covers, not their mean. The selected surface is thus at
+//! or below each sampled vertex, and one cell can never go through the
+//! adjacent cell. A clean cliff of two levels becomes one correct steep ramp.
+//! That ramp touches the low ground and the high ground exactly.
 
 use crate::map::*;
 use crate::util::*;
@@ -63,22 +61,22 @@ use brdb::{
 };
 use log::info;
 
-/// The largest half extent a procedural brick may carry, i.e. a 500-unit
-/// piece. A taller rise is split (foundations) or clamped down (slopes); it is
-/// never rounded UP, because that would push the surface above a sampled
-/// vertex and undo the fit-from-below guarantee.
+/// The largest half extent that a procedural brick can hold. It is a piece of
+/// 500 units. The code divides a higher foundation into more than one piece.
+/// It decreases a higher slope. It never increases a rise, because a higher
+/// surface would go above a sampled vertex.
 const MAX_HALF_EXTENT: i32 = 250;
 
-/// One cell's four corner heights, in the `(SW, SE, NE, NW)` order the whole
-/// grammar is calibrated in.
+/// The four corner heights of one cell. The sequence is `(SW, SE, NE, NW)`,
+/// which is the sequence used for all the calibrated shapes.
 pub type Corners = [i32; 4];
 
-/// Quarter turns counter-clockwise around `+Z`.
+/// The number of quarter turns counterclockwise around `+Z`.
 ///
-/// The grammar is compared and asserted on constantly -- fits are scored
-/// against each other, and every rotation convention below is pinned by a test
-/// -- and `brdb::Rotation` carries no `PartialEq`. This is that enum with an
-/// equality, converted at emission.
+/// The code compares shapes frequently. It gives each candidate a score, and a
+/// test holds each rotation rule below. But `brdb::Rotation` has no
+/// `PartialEq`. This type adds that comparison. The code changes it into a
+/// `Rotation` when it makes the brick.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Turn(pub u8);
 
@@ -87,8 +85,9 @@ impl Turn {
         Self(turns.rem_euclid(4) as u8)
     }
 
-    /// The half turn that pairs with this one, for the two complementary
-    /// triangles of a [`SurfaceKind::TrianglePair`].
+    /// The half turn that goes with this turn. A
+    /// [`SurfaceKind::TrianglePair`] uses the two turns for its two
+    /// triangles.
     fn opposite(self) -> Self {
         Self((self.0 + 2) % 4)
     }
@@ -103,33 +102,33 @@ impl Turn {
     }
 }
 
-/// Which assembly a cell resolves to. The `Turn` is already in Brickadia's own
-/// convention -- see the table in the module doc for what rotation zero means
-/// for each asset.
+/// The set of bricks that a cell becomes. The `Turn` already agrees with the
+/// Brickadia rules. The table in the module description shows what rotation
+/// zero means for each asset.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SurfaceKind {
-    /// One flat micro brick, top at `base`.
+    /// One flat micro brick. Its top is at `base`.
     Flat,
-    /// `PB_DefaultMicroRamp`: two adjacent corners high.
+    /// `PB_DefaultMicroRamp`. Two adjacent corners are high.
     Ramp(Turn),
-    /// `PB_DefaultMicroWedgeCorner`: exactly one corner high.
+    /// `PB_DefaultMicroWedgeCorner`. One corner only is high.
     Corner(Turn),
-    /// `PB_DefaultMicroWedgeInnerCorner`: exactly one corner low.
+    /// `PB_DefaultMicroWedgeInnerCorner`. One corner only is low.
     InnerCorner(Turn),
-    /// `PB_DefaultMicroWedgeOuterCorner` plus a `...TriangleCorner` one rise
-    /// above it: the diagonal `0,1,2,1` stack. Reducing this to a two-level
-    /// mask loses the upper triangle and leaves a visible step.
+    /// `PB_DefaultMicroWedgeOuterCorner` with a `...TriangleCorner` one rise
+    /// above it. This is the diagonal `0,1,2,1` stack. A mask of two levels
+    /// loses the upper triangle and leaves a step that you can see.
     OuterTriangle(Turn),
-    /// Two complementary `PB_DefaultMicroWedgeTriangleCorner`s covering the
-    /// whole square: opposite corners high.
+    /// Two `PB_DefaultMicroWedgeTriangleCorner` bricks that fill the square.
+    /// The two opposite corners are high.
     TrianglePair(Turn),
 }
 
 impl SurfaceKind {
-    /// How many bricks this assembly emits, foundation excluded. Used to break
-    /// ties between fits that deviate from the sampled corners equally: the
-    /// cheaper one wins, so a cell that a flat brick describes exactly never
-    /// spends a wedge on it.
+    /// The number of bricks in this set. It does not count the foundation.
+    /// Two candidates can have the same score. The code then keeps the
+    /// candidate with fewer bricks. A cell that one flat brick fits exactly
+    /// thus never gets a wedge.
     pub fn brick_count(self) -> u32 {
         match self {
             SurfaceKind::Flat => 1,
@@ -139,48 +138,52 @@ impl SurfaceKind {
     }
 }
 
-/// The chosen assembly for one cell, with the heights it actually fits.
+/// The selected set of bricks for one cell, with the heights that it fits.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct CellFit {
     pub kind: SurfaceKind,
-    /// Height of the assembly's LOWEST surface vertex, in layers.
+    /// The height of the LOWEST surface vertex, in layers.
     pub base: i32,
-    /// Rise of the load-bearing shape above `base`, in layers. Zero for
+    /// The rise of the main shape above `base`, in layers. It is zero for
     /// [`SurfaceKind::Flat`].
     pub rise: i32,
-    /// Rise of the triangle cap above `base + rise`, in layers.
-    /// [`SurfaceKind::OuterTriangle`] only.
+    /// The rise of the top triangle above `base + rise`, in layers. Only
+    /// [`SurfaceKind::OuterTriangle`] uses it.
     pub cap_rise: i32,
-    /// Total `sampled - fitted` over the four corners, in layers. Always
-    /// non-negative: every candidate is fitted from below.
+    /// The sum of `sampled - fitted` for the four corners, in layers. It is
+    /// never negative, because each candidate stays below the sample.
     pub error: i32,
 }
 
-/// Turn putting a shape's HIGH vertex at `corner`. Rotation zero is high at SW
-/// for both `MicroWedgeCorner` and `MicroWedgeTriangleCorner`, so the mapping
-/// is the identity: `SW/SE/NE/NW -> 0/90/180/270`.
+/// The turn that puts the HIGH vertex of a shape at `corner`. Rotation zero is
+/// high at SW for `MicroWedgeCorner` and for `MicroWedgeTriangleCorner`. The
+/// result is therefore direct: `SW/SE/NE/NW` gives `0/90/180/270`.
 fn turn_from_high_corner(corner: usize) -> Turn {
     Turn::new(corner as i32)
 }
 
-/// Turn putting a shape's LOW vertex at `corner`. Rotation zero is low at NE
-/// for both inner and outer corners, so the mapping is a half turn away from
-/// [`turn_from_high_corner`]: `low SW/SE/NE/NW -> 180/270/0/90`.
+/// The turn that puts the LOW vertex of a shape at `corner`. Rotation zero is
+/// low at NE for the inner corner and for the outer corner. The result is thus
+/// a half turn from [`turn_from_high_corner`]: a low `SW/SE/NE/NW` gives
+/// `180/270/0/90`.
 fn turn_from_low_corner(corner: usize) -> Turn {
     Turn::new(corner as i32 + 2)
 }
 
-/// Choose the assembly whose surface best matches four sampled corner heights.
+/// Select the set of bricks whose surface agrees best with four sampled corner
+/// heights.
 ///
-/// Enumerates the whole grammar -- flat, all fourteen two-level high/low
-/// partitions (which map onto ramp, corner, inner corner and triangle pair),
-/// and the four diagonal `0,1,2,1` stacks -- and scores each by the total
-/// height it leaves on the table. Every candidate is fitted FROM BELOW, so its
-/// score is a sum of non-negative residuals and the winning surface never rises
-/// above a sampled vertex.
+/// The code examines each shape that the rules permit: the flat shape, the
+/// fourteen divisions into a high group and a low group (these give the ramp,
+/// the corner, the inner corner and the triangle pair), and the four diagonal
+/// `0,1,2,1` stacks. It gives each candidate a score from the height that the
+/// candidate does not fill. Each candidate stays BELOW the sample, so each
+/// score is a sum of values that are not negative, and the selected surface
+/// never goes above a sampled vertex.
 ///
-/// Ties go to the assembly using fewer bricks, which is what keeps a flat
-/// region flat rather than paving it in zero-rise wedges.
+/// If two candidates have the same score, the code keeps the candidate with
+/// fewer bricks. A flat area thus stays flat and does not get wedges with no
+/// rise.
 pub fn fit_cell(corners: Corners) -> CellFit {
     let floor = *corners.iter().min().expect("four corners");
     let mut best = CellFit {
@@ -200,8 +203,9 @@ pub fn fit_cell(corners: Corners) -> CellFit {
         }
     };
 
-    // The fourteen two-level partitions. Bit `i` set means corner `i` is on the
-    // high level; 0 and 15 are the flat case already seeded above.
+    // The fourteen divisions into two levels. If bit `i` is set, corner `i` is
+    // on the high level. The masks 0 and 15 are the flat shape, which the code
+    // above already put in `best`.
     for mask in 1u8..15 {
         let high = |i: usize| mask >> i & 1 == 1;
         let low_level = (0..4)
@@ -216,31 +220,32 @@ pub fn fit_cell(corners: Corners) -> CellFit {
             .expect("a partition in 1..15 has a high corner");
         let rise = high_level - low_level;
         if rise <= 0 {
-            // Degenerate: the "high" level is not above the low one, so this
-            // partition describes the flat surface already considered.
+            // The "high" level is not above the low level. This division thus
+            // gives the flat surface, which the code already examined.
             continue;
         }
         let error = (0..4)
             .map(|i| corners[i] - if high(i) { low_level + rise } else { low_level })
             .sum();
         let kind = match mask {
-            // One raised vertex: a convex shoulder.
+            // One high vertex. This is a convex shoulder.
             1 | 2 | 4 | 8 => {
                 SurfaceKind::Corner(turn_from_high_corner(mask.trailing_zeros() as usize))
             }
-            // One low vertex: the concave transition. The OUTER corner has the
-            // same edge heights but the opposite internal triangulation and is
-            // reserved for the stacked diagonal case below, where its triangle
-            // cap completes the surface.
+            // One low vertex. This is the concave change. The OUTER corner has
+            // the same edge heights but the opposite internal triangles. The
+            // code keeps it for the diagonal stack below, where its top
+            // triangle completes the surface.
             7 | 11 | 13 | 14 => SurfaceKind::InnerCorner(turn_from_low_corner(
                 (!mask & 15).trailing_zeros() as usize,
             )),
-            // Opposite highs: two complementary triangles cover the square and
-            // preserve all four sampled corners.
+            // Two opposite corners are high. Two triangles then fill the
+            // square and keep all four sampled corners.
             5 => SurfaceKind::TrianglePair(Turn(0)),
             10 => SurfaceKind::TrianglePair(Turn(1)),
-            // Adjacent highs: a cardinal ramp, named by which way it steps
-            // DOWN. Rotation zero is low toward +X.
+            // Two adjacent corners are high. This is a ramp along an axis.
+            // Its name shows the direction in which it goes DOWN. Rotation
+            // zero is low at +X.
             9 => SurfaceKind::Ramp(Turn(0)),  // low NE+SE, i.e. +X
             3 => SurfaceKind::Ramp(Turn(1)),  // low NE+NW, i.e. +Y
             6 => SurfaceKind::Ramp(Turn(2)),  // low SW+NW, i.e. -X
@@ -256,10 +261,11 @@ pub fn fit_cell(corners: Corners) -> CellFit {
         });
     }
 
-    // The four diagonal stacks: one corner two rises up, the corner opposite it
-    // at the bottom, and the two between them in the middle. An orthogonal
-    // one-step limit does not prevent this, and collapsing it to a two-level
-    // mask is exactly what produces the broken transitions seen in game.
+    // The four diagonal stacks. One corner is two rises high, the opposite
+    // corner is at the bottom, and the other two corners are between them. A
+    // limit of one step between adjacent vertices does not prevent this shape.
+    // A mask of two levels gives the incorrect changes that occur in the
+    // game.
     for high in 0..4 {
         let bottom = corners[(high + 2) & 3];
         let middle = corners[(high + 1) & 3].min(corners[(high + 3) & 3]);
@@ -274,8 +280,8 @@ pub fn fit_cell(corners: Corners) -> CellFit {
             base: bottom,
             rise,
             cap_rise,
-            // The bottom and top corners are matched exactly; only the two
-            // middle ones can differ, and only by however far apart they are.
+            // The bottom corner and the top corner agree exactly. Only the
+            // two middle corners can differ, by the distance between them.
             error: (corners[(high + 1) & 3] - middle) + (corners[(high + 3) & 3] - middle),
         });
     }
@@ -283,19 +289,19 @@ pub fn fit_cell(corners: Corners) -> CellFit {
     best
 }
 
-/// Generate smooth micro-wedge terrain from a heightmap.
+/// Make smooth micro wedge terrain from a heightmap.
 ///
-/// Heights are read on a shared `(w+1) x (h+1)` vertex grid: vertex `(i, j)` is
-/// the mean of the up-to-four pixels touching it. That keeps the output exactly
-/// one cell per pixel -- the same footprint every other mode produces -- while
-/// giving neighbouring cells the shared corner heights the grammar needs, and
-/// it costs one bilinear smoothing pass that a heightmap generally wants
-/// anyway.
+/// The code reads the heights from a shared grid of `(w+1) x (h+1)` vertices.
+/// Vertex `(i, j)` is the mean of the four pixels that touch it, or of fewer
+/// pixels at an edge. The output keeps one cell for each pixel, which is the
+/// same area that the other modes give. But adjacent cells then get the shared
+/// corner heights that the shapes need. The cost is one smoothing pass, which
+/// is usually good for a heightmap.
 ///
-/// Under `--terrain` the vertical scale is a LAYER height rather than a raw
-/// unit count: one shade of grey is one layer, `rise_unit` units tall. It is
-/// rounded up to an even number and floored at 2 because a wedge's `BrickSize`
-/// half height must be a whole unit.
+/// With `--terrain`, the vertical scale gives the height of one LAYER, not a
+/// count of units. One level of grey is one layer of `rise_unit` units. The
+/// code increases `rise_unit` to an even number and to a minimum of 2, because
+/// the half height in a `BrickSize` must be a whole unit.
 pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
     heightmap: &dyn Heightmap,
     colormap: &dyn Colormap,
@@ -319,9 +325,9 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
         return Err("Heightmap is empty".to_string());
     }
 
-    // Rounded UP to even, floored at 2: a rise of `rise_unit` units is emitted
-    // as a `BrickSize` half height of `rise_unit / 2`, which must be a whole
-    // unit and must not be zero.
+    // Increased to an even number, with a minimum of 2. A rise of `rise_unit`
+    // units becomes a `BrickSize` half height of `rise_unit / 2`. That value
+    // must be a whole unit and must not be zero.
     let scale = options.scale.max(1) as i32;
     let rise_unit = scale + (scale & 1);
     if rise_unit != scale {
@@ -362,9 +368,10 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
         ]
     };
 
-    // Pass one records only each cell's floor, which is all the foundation
-    // depths below need. Keeping the fits themselves would cost five times the
-    // memory on a map where a full brick list is already the binding limit.
+    // This pass keeps the floor of each cell only, because the foundation
+    // depths below need no more. To keep the selected shapes would use five
+    // times more memory, and on a large map the list of bricks is already the
+    // limit.
     info!("Classifying cells");
     let mut floors = vec![0i32; width as usize * height as usize];
     let mut culled = vec![false; width as usize * height as usize];
@@ -372,8 +379,9 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
         for x in 0..width {
             let index = y as usize * width as usize + x as usize;
             let color = colormap.at(x, y);
-            // Same rule the blocky modes use: with --cull, a fully transparent
-            // pixel and a bottom-level pixel are both dropped.
+            // This is the rule that the other modes use. With --cull, the
+            // code removes a fully transparent pixel and a pixel at the lowest
+            // level.
             culled[index] = options.cull && (heightmap.at(x, y) == 0 || color[3] == 0);
             floors[index] = *corners_at(x, y).iter().min().expect("four corners");
         }
@@ -383,27 +391,28 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
     }
     progress!(0.5);
 
-    // Centred exactly as the blocky modes centre their output, so switching
-    // modes does not move the build.
+    // The center agrees with the center that the other modes give, so a
+    // change of mode does not move the build.
     let layout = Layout {
         half,
         rise_unit,
         offset_x: -(width as i32 * half),
         offset_y: -(height as i32 * half),
-        // Surface of layer zero, matching where the blocky modes put the top of
-        // a zero-height cell.
+        // The surface of layer zero. The other modes put the top of a cell of
+        // height zero at the same position.
         z_floor: options.base_height() - 5,
         glow: options.glow,
         collision: options.collision(),
     };
 
-    // How deep a cell's foundation has to reach: below the lowest neighbouring
-    // floor, which is what closes a cliff face from the high side. The `+ 1`
-    // keeps a flat plain one layer thick instead of zero.
+    // The depth that the foundation of a cell must reach. It goes below the
+    // lowest floor of the adjacent cells, which closes the face of a cliff
+    // from the high side. The `+ 1` gives a flat plain a thickness of one
+    // layer and not of zero.
     //
-    // A closure rather than a stored field: it is a pure function of `floors`,
-    // and a map big enough for this to matter is a map where another `i32` per
-    // cell is the thing that hurts.
+    // This is a closure and not a stored array, because the result comes from
+    // `floors` only. On a map that is large enough for the speed to be
+    // important, one more `i32` for each cell is the larger problem.
     let depth_layers = |x: u32, y: u32| -> i32 {
         let index = y as usize * width as usize + x as usize;
         let mut lowest = floors[index];
@@ -494,17 +503,17 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
     Ok(bricks)
 }
 
-/// Where the terrain's cell grid sits in world units, and how bricks are
-/// styled. Bundled so the surface pass and the foundation pass cannot drift
-/// apart on the centring, the ground plane, or the material.
+/// The position of the cell grid in world units, and the appearance of the
+/// bricks. These values stay together, so the surface pass and the foundation
+/// pass always agree about the center, the ground level and the material.
 struct Layout {
-    /// Half extent of one cell in X and Y, in units.
+    /// The half extent of one cell in X and Y, in units.
     half: i32,
-    /// Units per terrain layer. Even, and at least 2.
+    /// The number of units in one terrain layer. It is even and is 2 or more.
     rise_unit: i32,
     offset_x: i32,
     offset_y: i32,
-    /// World Z of the surface of layer zero.
+    /// The world Z of the surface of layer zero.
     z_floor: i32,
     glow: bool,
     collision: brdb::Collision,
@@ -534,20 +543,20 @@ impl Layout {
     }
 }
 
-/// Emit the foundation layer as as few boxes as the grid allows.
+/// Make the foundation layer from as few boxes as the grid permits.
 ///
-/// A foundation is a flat-topped prism, so the foundation layer is an ordinary
-/// 2D field of `(colour, top, depth)` and merges the way the blocky renderers
-/// merge their prisms. Without this the surface grammar's one-shape-per-cell
-/// rule leaked into the part of the build nobody can see: a flat plain cost one
-/// brick per PIXEL under `--terrain` while the same plain under `--micro` cost
-/// one brick for the whole region.
+/// A foundation is a box with a flat top. The foundation layer is thus a
+/// usual 2D field of `(color, top, depth)`, and it joins in the same way as
+/// the boxes of the other modes. Before this pass, the rule of one shape for
+/// each cell also applied to the part of the build that you cannot see: with
+/// `--terrain` a flat plain used one brick for each PIXEL, but the same plain
+/// with `--micro` used one brick for the full area.
 ///
-/// Cells join a box only when their colour, top AND depth all match exactly.
-/// Unifying mismatched depths to the deepest one would merge far more
-/// aggressively, but it also hangs solid material below where a shallower cell
-/// ended -- which is invisible on a plain and very visible from inside a
-/// canyon, where the cliff base is the thing being looked at.
+/// Cells go into the same box only if their color, top AND depth all agree
+/// exactly. To give a group the largest depth in that group would join many
+/// more cells. But it would also put material below the bottom of a cell that
+/// is less deep. You cannot see that material on a plain, but you see it
+/// clearly in a canyon, where the bottom of the cliff is what you look at.
 #[allow(clippy::too_many_arguments)]
 fn merge_foundations<F: Fn(f32) -> bool, D: Fn(u32, u32) -> i32>(
     out: &mut Vec<Brick>,
@@ -560,7 +569,7 @@ fn merge_foundations<F: Fn(f32) -> bool, D: Fn(u32, u32) -> i32>(
     progress_f: &F,
 ) -> Result<usize, String> {
     let mut taken = vec![false; width as usize * height as usize];
-    // A box may not exceed 500 units on any axis.
+    // A box must not be more than 500 units on an axis.
     let max_run = (MAX_HALF_EXTENT / layout.half).max(1) as u32;
     let mut emitted = 0usize;
 
@@ -596,8 +605,8 @@ fn merge_foundations<F: Fn(f32) -> bool, D: Fn(u32, u32) -> i32>(
             'rows: while run_y < max_run && y + run_y < height {
                 for dx in 0..run_x {
                     if !joins(x + dx, y + run_y, top, depth, color, &taken) {
-                        // A partial row is discarded whole: the box has to stay
-                        // rectangular.
+                        // The code rejects the full row, because the box must
+                        // stay rectangular.
                         break 'rows;
                     }
                 }
@@ -610,8 +619,9 @@ fn merge_foundations<F: Fn(f32) -> bool, D: Fn(u32, u32) -> i32>(
                 }
             }
 
-            // Top flush with the cell floor, split into 500-unit slabs because
-            // that is the tallest procedural brick the format can carry.
+            // The top is level with the cell floor. The code divides the box
+            // into pieces of 500 units, because that is the highest procedural
+            // brick that the format holds.
             let mut remaining = (depth * layout.rise_unit).max(2);
             let mut top_units = layout.z_floor + top * layout.rise_unit;
             while remaining > 0 {
@@ -647,14 +657,15 @@ fn merge_foundations<F: Fn(f32) -> bool, D: Fn(u32, u32) -> i32>(
     Ok(emitted)
 }
 
-/// Emit one cell's SURFACE: the load-bearing shape, plus the triangle cap or
-/// complementary triangle where the fit calls for one. The foundation under it
-/// is not emitted here -- foundations are flat-topped prisms and merge across
-/// cells, so [`merge_foundations`] lays the whole layer at once.
+/// Make the SURFACE of one cell: the main shape, with the top triangle or the
+/// second triangle if the selected shape needs one. This function does not
+/// make the foundation below. Foundations are boxes with flat tops that join
+/// across cells, so [`merge_foundations`] makes the full layer together.
 ///
-/// `anchor` carries the cell's centre in X/Y and the altitude of its LOWEST
-/// surface vertex in Z -- what the geometry contract calls `base`. A flat cell
-/// emits nothing at all: its foundation's top face IS its surface.
+/// `anchor` gives the center of the cell in X and Y, and the height of its
+/// LOWEST surface vertex in Z. The geometry rules call that height `base`. A
+/// flat cell makes no brick here, because the top face of its foundation IS
+/// its surface.
 fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Position, color: Color) {
     let half = layout.half as u16;
     let mut piece = |asset, size: BrickSize, z: i32, turn: Turn| {
@@ -667,9 +678,9 @@ fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Posit
         ));
     };
 
-    // A rise is CLAMPED, never rounded up: raising it would push the surface
-    // above a sampled vertex and break the fit-from-below guarantee that keeps
-    // one cell from protruding through its neighbour.
+    // The code DECREASES a rise that is too large. It never increases a rise,
+    // because a higher surface would go above a sampled vertex. One cell would
+    // then go through the adjacent cell.
     let rise = (fit.rise * layout.rise_unit).min(MAX_HALF_EXTENT * 2);
     let cap = (fit.cap_rise * layout.rise_unit).min(MAX_HALF_EXTENT * 2);
     let (asset, turn, second) = match fit.kind {
@@ -677,9 +688,10 @@ fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Posit
         SurfaceKind::Ramp(t) => (PB_DEFAULT_MICRO_RAMP, t, None),
         SurfaceKind::Corner(t) => (PB_DEFAULT_MICRO_WEDGE_CORNER, t, None),
         SurfaceKind::InnerCorner(t) => (PB_DEFAULT_MICRO_WEDGE_INNER_CORNER, t, None),
-        // The cap shares the outer corner's rotation: the outer corner is low
-        // at NE under rotation zero and the triangle is high at SW, which are
-        // the same quarter turn away from the cell's high vertex.
+        // The top triangle uses the rotation of the outer corner. At rotation
+        // zero the outer corner is low at NE and the triangle is high at SW.
+        // Both are thus the same quarter turn from the high vertex of the
+        // cell.
         SurfaceKind::OuterTriangle(t) => (PB_DEFAULT_MICRO_WEDGE_OUTER_CORNER, t, Some(t)),
         SurfaceKind::TrianglePair(t) => (
             PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
@@ -688,8 +700,8 @@ fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Posit
         ),
     };
     if rise < 2 {
-        // The whole rise vanished under the layer quantization; the foundation
-        // already covers this cell as a flat top.
+        // The layer height removed the full rise. The foundation already gives
+        // this cell a flat top.
         return;
     }
     piece(
@@ -703,16 +715,17 @@ fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Posit
         return;
     };
     match fit.kind {
-        // The cap of a diagonal stack sits one full rise higher and is sized
-        // independently, from the middle level to the top one.
+        // The top triangle of a diagonal stack is one full rise higher. Its
+        // height comes from the middle level to the top level.
         SurfaceKind::OuterTriangle(_) if cap >= 2 => piece(
             PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
             BrickSize::new(half, half, (cap / 2) as u16),
             anchor.z + rise + cap / 2,
             second_turn,
         ),
-        // The two triangles of a pair are the same size in the same place; only
-        // their rotations differ, and together they tile the square.
+        // The two triangles of a pair have the same size and the same
+        // position. Only their rotations differ, and together they fill the
+        // square.
         SurfaceKind::TrianglePair(_) => piece(
             PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
             BrickSize::new(half, half, (rise / 2) as u16),
@@ -726,43 +739,48 @@ fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Posit
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
-    /// Corners are `(SW, SE, NE, NW)`.
+    /// The corner sequence is `(SW, SE, NE, NW)`.
     const SW: usize = 0;
     const SE: usize = 1;
     const NE: usize = 2;
     const NW: usize = 3;
 
+    /// A flat cell must become one flat brick and must lose no height. A wedge
+    /// with no rise gives the same score, so this also holds the rule that
+    /// selects the candidate with fewer bricks.
     #[test]
-    fn a_level_cell_is_one_flat_brick_with_no_residual() {
+    fn a_level_cell_becomes_one_flat_brick() {
         let fit = fit_cell([7, 7, 7, 7]);
         assert_eq!(fit.kind, SurfaceKind::Flat);
         assert_eq!((fit.base, fit.rise, fit.error), (7, 0, 0));
+        assert_eq!(fit.kind.brick_count(), 1);
     }
 
-    /// Rotation zero steps DOWN toward `+X`, so a cell high on its `-X` edge
-    /// (SW and NW) is the rotation-zero ramp. Each quarter turn moves the low
-    /// edge counter-clockwise.
+    /// Rotation zero goes DOWN at `+X`. A cell that is high on its `-X` edge
+    /// (at SW and NW) is thus the ramp at rotation zero. Each quarter turn
+    /// moves the low edge counterclockwise.
     #[test]
     fn ramps_face_the_way_the_cell_steps_down() {
         for (corners, expected) in [
-            ([1, 0, 0, 1], Turn(0)), // low toward +X
-            ([1, 1, 0, 0], Turn(1)), // low toward +Y
-            ([0, 1, 1, 0], Turn(2)), // low toward -X
-            ([0, 0, 1, 1], Turn(3)), // low toward -Y
+            ([1, 0, 0, 1], Turn(0)), // low at +X
+            ([1, 1, 0, 0], Turn(1)), // low at +Y
+            ([0, 1, 1, 0], Turn(2)), // low at -X
+            ([0, 0, 1, 1], Turn(3)), // low at -Y
         ] {
             let fit = fit_cell(corners);
             assert_eq!(
                 fit.kind,
                 SurfaceKind::Ramp(expected),
-                "corners {corners:?} must ramp down the opposite way from its high edge"
+                "the corners {corners:?} must go down opposite to the high edge"
             );
             assert_eq!((fit.base, fit.rise, fit.error), (0, 1, 0));
         }
     }
 
-    /// A single raised vertex is a full wedge corner, and rotation zero puts
-    /// the high point at SW.
+    /// One high vertex must give a full wedge corner. Rotation zero puts the
+    /// high point at SW.
     #[test]
     fn one_high_vertex_is_a_wedge_corner_rotated_onto_it() {
         for corner in [SW, SE, NE, NW] {
@@ -772,14 +790,14 @@ mod tests {
             assert_eq!(
                 fit.kind,
                 SurfaceKind::Corner(Turn::new(corner as i32)),
-                "a high {corner} must rotate the corner's SW high point onto it"
+                "a high corner {corner} must move the SW high point of the wedge onto it"
             );
-            assert_eq!(fit.error, 0, "a one-high cell is exactly representable");
+            assert_eq!(fit.error, 0, "a cell with one high corner fits exactly");
         }
     }
 
-    /// A single LOW vertex is the inner corner, whose rotation zero is low at
-    /// NE -- a half turn away from the wedge corner's convention.
+    /// One LOW vertex must give the inner corner. Rotation zero is low at NE,
+    /// which is a half turn from the rule for the wedge corner.
     #[test]
     fn one_low_vertex_is_an_inner_corner_a_half_turn_from_the_high_convention() {
         for corner in [SW, SE, NE, NW] {
@@ -789,12 +807,15 @@ mod tests {
             assert_eq!(
                 fit.kind,
                 SurfaceKind::InnerCorner(Turn::new(corner as i32 + 2)),
-                "a low {corner} must rotate the inner corner's NE low point onto it"
+                "a low corner {corner} must move the NE low point of the inner corner onto it"
             );
             assert_eq!(fit.error, 0);
         }
     }
 
+    /// Two opposite high vertices must give two triangles. The two turns must
+    /// be a half turn apart. If they were not, the triangles would cover one
+    /// diagonal two times and leave the other diagonal open.
     #[test]
     fn opposite_high_vertices_become_a_complementary_triangle_pair() {
         assert_eq!(
@@ -805,17 +826,16 @@ mod tests {
             fit_cell([0, 1, 0, 1]).kind,
             SurfaceKind::TrianglePair(Turn(1))
         );
-        // The two triangles must be half a turn apart, or they would overlap on
-        // one diagonal and leave the other uncovered.
         let SurfaceKind::TrianglePair(turn) = fit_cell([1, 0, 1, 0]).kind else {
-            panic!("opposite highs are a triangle pair");
+            panic!("two opposite high corners give a triangle pair");
         };
         assert_eq!((turn.opposite().0 + 4 - turn.0) % 4, 2);
     }
 
-    /// The row the geometry contract calls essential: an orthogonal one-step
-    /// limit does NOT stop opposite corners differing by two, and reducing that
-    /// case to a two-level mask loses the upper triangle.
+    /// The geometry rules call this shape necessary. A limit of one step
+    /// between adjacent vertices does not prevent two opposite corners from
+    /// differing by two levels, and a mask of two levels loses the upper
+    /// triangle.
     #[test]
     fn a_diagonal_two_layer_cell_stacks_a_triangle_on_an_outer_corner() {
         for high in [SW, SE, NE, NW] {
@@ -826,15 +846,15 @@ mod tests {
             assert_eq!(
                 fit.kind,
                 SurfaceKind::OuterTriangle(Turn::new(high as i32)),
-                "corners {corners:?} need the diagonal stack, not a flattened mask"
+                "the corners {corners:?} need the diagonal stack, not a mask of two levels"
             );
             assert_eq!((fit.base, fit.rise, fit.cap_rise, fit.error), (0, 1, 1, 0));
         }
     }
 
-    /// The whole point of scoring every candidate: a cliff is not slope
-    /// limited, and the grammar still has to answer for it. A clean two-level
-    /// fault must come back as ONE exact steep ramp, not a shelf.
+    /// This is the reason to give each candidate a score. A heightmap has no
+    /// slope limit, and the shapes must still answer for a cliff. A clean
+    /// cliff of two levels must give ONE correct steep ramp and not a shelf.
     #[test]
     fn a_cliff_resolves_to_one_exact_steep_ramp() {
         let fit = fit_cell([0, 40, 40, 0]);
@@ -842,80 +862,61 @@ mod tests {
         assert_eq!((fit.base, fit.rise, fit.error), (0, 40, 0));
     }
 
-    /// Fit FROM BELOW. Every candidate takes the minimum of the corners it
-    /// covers, so no fitted surface may sit above a sampled vertex -- that is
-    /// what stops one cell protruding through its neighbour.
+    /// The two rules that make cells touch, over each small four-corner field.
+    ///
+    /// The fit must stay at or below each sampled corner, because a higher
+    /// surface would go through the adjacent cell. And where the shapes can
+    /// give an exact answer, the fit must be exact. If it were not, a smooth
+    /// field would show steps where the shapes cover it.
     #[test]
-    fn no_fitted_surface_ever_rises_above_a_sampled_corner() {
-        // An exhaustive sweep over small four-corner fields, including every
-        // pattern outside the sloped grammar.
+    fn the_fit_stays_below_the_sample_and_is_exact_where_the_shapes_allow() {
+        let mut exact = 0;
         for a in 0..4 {
             for b in 0..4 {
                 for c in 0..4 {
                     for d in 0..4 {
                         let corners = [a, b, c, d];
                         let fit = fit_cell(corners);
+                        let low = *corners.iter().min().unwrap();
+                        let high = *corners.iter().max().unwrap();
                         assert!(
-                            fit.error >= 0,
-                            "corners {corners:?} fitted above the sample: error {}",
-                            fit.error
+                            fit.error >= 0 && fit.base <= low,
+                            "the corners {corners:?} fitted above the sample"
                         );
-                        assert!(fit.base <= *corners.iter().min().unwrap());
                         assert!(fit.rise >= 0 && fit.cap_rise >= 0);
                         assert!(
-                            fit.base + fit.rise + fit.cap_rise <= *corners.iter().max().unwrap(),
-                            "corners {corners:?} fitted a peak above the highest sample"
+                            fit.base + fit.rise + fit.cap_rise <= high,
+                            "the corners {corners:?} put a peak above the highest sample"
                         );
-                    }
-                }
-            }
-        }
-    }
 
-    /// Anything the grammar can express exactly, it must express exactly --
-    /// otherwise a smooth field would render with residual steps even where the
-    /// vocabulary covers it.
-    #[test]
-    fn every_representable_cell_is_fitted_with_no_residual() {
-        let mut representable = 0;
-        for a in 0..3 {
-            for b in 0..3 {
-                for c in 0..3 {
-                    for d in 0..3 {
-                        let corners = [a, b, c, d];
-                        let range = corners.iter().max().unwrap() - corners.iter().min().unwrap();
-                        // Two-level cells and the diagonal 0-1-2-1 stack are the
-                        // whole vocabulary; a cell needs to be one of them.
+                        // A cell is inside the shapes if it has two levels, or
+                        // if it is the diagonal 0-1-2-1 stack.
                         let levels: std::collections::BTreeSet<_> = corners.iter().collect();
-                        let diagonal_stack = range == 2
+                        let stack = high - low == 2
                             && levels.len() == 3
                             && (0..4).any(|k| {
-                                corners[k] == 2
-                                    && corners[(k + 2) & 3] == 0
-                                    && corners[(k + 1) & 3] == 1
-                                    && corners[(k + 3) & 3] == 1
+                                corners[k] == high
+                                    && corners[(k + 2) & 3] == low
+                                    && corners[(k + 1) & 3] == low + 1
+                                    && corners[(k + 3) & 3] == low + 1
                             });
-                        if levels.len() > 2 && !diagonal_stack {
-                            continue;
+                        if levels.len() <= 2 || stack {
+                            exact += 1;
+                            assert_eq!(
+                                fit.error, 0,
+                                "the corners {corners:?} are inside the shapes and must fit \
+                                 exactly"
+                            );
                         }
-                        representable += 1;
-                        assert_eq!(
-                            fit_cell(corners).error,
-                            0,
-                            "corners {corners:?} are inside the grammar and must fit exactly"
-                        );
                     }
                 }
             }
         }
-        assert!(
-            representable > 40,
-            "the sweep must actually cover the grammar"
-        );
+        assert!(exact > 40, "the loop must cover the shapes");
     }
 
-    /// A constant-height, constant-colour heightmap, for exercising the
-    /// foundation merge against the case it exists for.
+    /// A heightmap of one height and one color, to exercise the pass that
+    /// joins the foundations.
     struct Flat(u32, u32, u32);
     impl Heightmap for Flat {
         fn at(&self, _x: u32, _y: u32) -> u32 {
@@ -925,8 +926,8 @@ mod tests {
             (self.0, self.1)
         }
     }
-    /// A height field with one step across the middle, so foundations have two
-    /// different depths and must not merge across the break.
+    /// A height field with one step at the middle, so the foundations get two
+    /// different depths.
     struct Step(u32, u32);
     impl Heightmap for Step {
         fn at(&self, x: u32, _y: u32) -> u32 {
@@ -945,7 +946,7 @@ mod tests {
             (self.0, self.1)
         }
     }
-    /// One distinct colour per pixel: nothing may merge.
+    /// A different color for each pixel, so no two cells can join.
     struct Rainbow(u32, u32);
     impl Colormap for Rainbow {
         fn at(&self, x: u32, y: u32) -> [u8; 4] {
@@ -976,112 +977,106 @@ mod tests {
         }
     }
 
-    /// The whole point of the merge pass: a flat plain is one flat-topped
-    /// prism, not one per pixel. Before it existed this render cost 1024
-    /// bricks.
+    fn foundations(bricks: &[Brick]) -> impl Iterator<Item = (&Brick, BrickSize)> {
+        bricks.iter().filter_map(|brick| {
+            let BrickType::Procedural { asset, size } = &brick.asset else {
+                unreachable!("terrain makes procedural bricks only")
+            };
+            (asset.as_ref() == "PB_DefaultMicroBrick").then_some((brick, *size))
+        })
+    }
+
+    /// The purpose of the pass that joins foundations. A flat plain must be a
+    /// small number of boxes. Before that pass this render used 1024 bricks.
     #[test]
-    fn a_uniform_plain_collapses_to_a_handful_of_foundation_boxes() {
+    fn a_uniform_plain_collapses_to_a_few_foundation_boxes() {
         let bricks =
             gen_terrain_heightmap(&Flat(32, 32, 4), &Grey(32, 32), options(), |_| true).unwrap();
         assert!(
             bricks.len() < 8,
-            "1024 identical cells collapsed to only {} brick(s)",
+            "1024 equal cells gave {} brick(s)",
             bricks.len()
         );
-        // ...and it really is flat, so nothing paid for a wedge either.
-        assert!(bricks.iter().all(|b| {
-            let BrickType::Procedural { asset, .. } = &b.asset else {
-                unreachable!()
-            };
-            asset.as_ref() == "PB_DefaultMicroBrick"
-        }));
+        assert_eq!(
+            foundations(&bricks).count(),
+            bricks.len(),
+            "a flat plain must have no wedges"
+        );
     }
 
-    /// The merge must be driven by the field, not by luck: a colormap with a
-    /// different colour on every pixel has nothing to merge, and must still
-    /// cover every cell.
+    /// The field and not chance must control the joins. Cells join only if the
+    /// color AND the depth agree.
+    ///
+    /// A box across a change of depth would open the face of the cliff or
+    /// would put material below the bottom of the low cell.
     #[test]
-    fn a_per_pixel_colormap_merges_nothing_and_still_covers_every_cell() {
+    fn foundations_only_merge_where_color_and_depth_agree() {
         let bricks =
             gen_terrain_heightmap(&Flat(16, 16, 4), &Rainbow(16, 16), options(), |_| true).unwrap();
         assert_eq!(
             bricks.len(),
             256,
-            "distinct colours cannot share a box, so every cell needs its own"
+            "cells with different colors cannot share a box"
         );
-    }
 
-    /// Foundations of different depths must not join. A box spanning the step
-    /// would either leave the cliff face open or hang material below the low
-    /// side.
-    #[test]
-    fn foundations_never_merge_across_a_change_in_depth() {
         let bricks =
             gen_terrain_heightmap(&Step(16, 16), &Grey(16, 16), options(), |_| true).unwrap();
-        let cell = 10; // options().size is a half extent, so a cell is 10 units
-        let left_edge = -(16 * 5);
-        // No foundation may straddle the seam at the middle of the map.
-        let seam = left_edge + 8 * cell;
-        for brick in &bricks {
-            let BrickType::Procedural { asset, size } = &brick.asset else {
-                unreachable!()
-            };
-            if asset.as_ref() != "PB_DefaultMicroBrick" {
-                continue;
-            }
+        // `options().size` is a half extent, so one cell is 10 units.
+        let seam = -(16 * 5) + 8 * 10;
+        for (brick, size) in foundations(&bricks) {
             let low = brick.position.x - size.x as i32;
             let high = brick.position.x + size.x as i32;
             assert!(
                 low >= seam || high <= seam,
-                "a foundation spans the step from {low} to {high} (seam at {seam})"
+                "a foundation goes from {low} to {high} across the step at {seam}"
             );
         }
     }
 
-    /// The merge is an optimization, so it must not change what is solid. Every
-    /// cell's foundation column has to come back covered, exactly once, from
-    /// its own top down to its own depth.
+    /// The joins are an optimization, so they must not change the material.
+    /// Each cell must get one foundation column, one time only, and that
+    /// column must reach the surface of its own cell.
     #[test]
-    fn merging_covers_the_same_volume_one_cell_at_a_time_would_have() {
+    fn merging_covers_every_cell_exactly_once() {
+        let (side, cell) = (12i32, 10i32);
         let bricks =
             gen_terrain_heightmap(&Step(12, 12), &Grey(12, 12), options(), |_| true).unwrap();
-        let cell = 10;
-        let origin = -(12 * 5);
-        let mut covered = std::collections::HashMap::<(i32, i32), (i32, i32)>::new();
-        for brick in &bricks {
-            let BrickType::Procedural { asset, size } = &brick.asset else {
-                unreachable!()
-            };
-            if asset.as_ref() != "PB_DefaultMicroBrick" {
-                continue;
-            }
+        let origin = -(side * 5);
+
+        let mut columns = HashMap::<(i32, i32), Vec<(i32, i32)>>::new();
+        for (brick, size) in foundations(&bricks) {
             let x0 = (brick.position.x - size.x as i32 - origin) / cell;
             let y0 = (brick.position.y - size.y as i32 - origin) / cell;
+            let span = (
+                brick.position.z - size.z as i32,
+                brick.position.z + size.z as i32,
+            );
             for dx in 0..(size.x as i32 * 2 / cell) {
                 for dy in 0..(size.y as i32 * 2 / cell) {
-                    let span = (
-                        brick.position.z - size.z as i32,
-                        brick.position.z + size.z as i32,
-                    );
-                    let entry = covered.entry((x0 + dx, y0 + dy)).or_insert(span);
-                    *entry = (entry.0.min(span.0), entry.1.max(span.1));
+                    columns.entry((x0 + dx, y0 + dy)).or_default().push(span);
                 }
             }
         }
-        assert_eq!(covered.len(), 144, "every cell must carry a foundation");
-        // A uniform half of the map is one depth and the other half another, so
-        // both cases are represented; what matters is that each column is a
-        // single contiguous span reaching its own surface.
-        for ((x, y), (low, high)) in &covered {
-            assert!(high > low, "cell ({x}, {y}) has an empty foundation");
-        }
-    }
+        assert_eq!(
+            columns.len() as i32,
+            side * side,
+            "each cell must get a foundation"
+        );
 
-    #[test]
-    fn a_flat_cell_never_pays_for_a_wedge_when_a_brick_would_do() {
-        // Same residual as several zero-information wedge fits; the tie-break
-        // must take the single brick.
-        assert_eq!(fit_cell([5, 5, 5, 5]).kind.brick_count(), 1);
-        assert_eq!(fit_cell([5, 5, 5, 5]).kind, SurfaceKind::Flat);
+        for ((x, y), spans) in &columns {
+            let mut spans = spans.clone();
+            spans.sort_unstable();
+            // The tops of a divided column must touch, with no gap and no
+            // overlap. `Step` is not high enough to divide a column, but the
+            // check must hold if it were.
+            for pair in spans.windows(2) {
+                assert_eq!(
+                    pair[0].1, pair[1].0,
+                    "the foundation of the cell ({x}, {y}) has a gap or an overlap"
+                );
+            }
+            let (low, high) = (spans[0].0, spans.last().unwrap().1);
+            assert!(high > low, "the cell ({x}, {y}) has an empty foundation");
+        }
     }
 }

--- a/src/opt/terrain.rs
+++ b/src/opt/terrain.rs
@@ -383,15 +383,41 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
     }
     progress!(0.5);
 
-    info!("Building terrain assemblies");
     // Centred exactly as the blocky modes centre their output, so switching
     // modes does not move the build.
-    let offset_x = -(width as i32 * half);
-    let offset_y = -(height as i32 * half);
-    // Surface of layer zero, matching where the blocky modes put the top of a
-    // zero-height cell.
-    let z_floor = options.base_height() - 5;
+    let layout = Layout {
+        half,
+        rise_unit,
+        offset_x: -(width as i32 * half),
+        offset_y: -(height as i32 * half),
+        // Surface of layer zero, matching where the blocky modes put the top of
+        // a zero-height cell.
+        z_floor: options.base_height() - 5,
+        glow: options.glow,
+        collision: options.collision(),
+    };
 
+    // How deep a cell's foundation has to reach: below the lowest neighbouring
+    // floor, which is what closes a cliff face from the high side. The `+ 1`
+    // keeps a flat plain one layer thick instead of zero.
+    //
+    // A closure rather than a stored field: it is a pure function of `floors`,
+    // and a map big enough for this to matter is a map where another `i32` per
+    // cell is the thing that hurts.
+    let depth_layers = |x: u32, y: u32| -> i32 {
+        let index = y as usize * width as usize + x as usize;
+        let mut lowest = floors[index];
+        for (dx, dy) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+            let nx = x as i32 + dx;
+            let ny = y as i32 + dy;
+            if nx >= 0 && ny >= 0 && (nx as u32) < width && (ny as u32) < height {
+                lowest = lowest.min(floors[ny as usize * width as usize + nx as usize]);
+            }
+        }
+        (floors[index] - lowest).max(0) + 1
+    };
+
+    info!("Building terrain assemblies");
     let mut bricks: Vec<Brick> = Vec::new();
     let mut counts = [0usize; 6];
     for y in 0..height {
@@ -410,32 +436,16 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
                 SurfaceKind::TrianglePair(_) => 5,
             }] += 1;
 
-            // The foundation reaches below the lowest neighbouring floor, which
-            // is what closes a cliff face from the high side. `+ 1` layer keeps
-            // a flat plain one layer thick instead of zero.
-            let mut lowest = floors[index];
-            for (dx, dy) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
-                let nx = x as i32 + dx;
-                let ny = y as i32 + dy;
-                if nx >= 0 && ny >= 0 && (nx as u32) < width && (ny as u32) < height {
-                    lowest = lowest.min(floors[ny as usize * width as usize + nx as usize]);
-                }
-            }
-            let depth = ((floors[index] - lowest).max(0) + 1) * rise_unit;
-
             let color = colormap.at(x, y);
-            emit_cell(
+            emit_slope(
                 &mut bricks,
-                &options,
+                &layout,
                 fit,
                 Position::new(
-                    (x as i32 * 2 + 1) * half + offset_x,
-                    (y as i32 * 2 + 1) * half + offset_y,
-                    z_floor + fit.base * rise_unit,
+                    (x as i32 * 2 + 1) * layout.half + layout.offset_x,
+                    (y as i32 * 2 + 1) * layout.half + layout.offset_y,
+                    layout.z_floor + fit.base * rise_unit,
                 ),
-                half,
-                rise_unit,
-                depth,
                 Color {
                     r: color[0],
                     g: color[1],
@@ -444,9 +454,22 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
             );
         }
         if y % 32 == 0 {
-            progress!(0.5 + 0.45 * (y as f32 / height as f32));
+            progress!(0.5 + 0.35 * (y as f32 / height as f32));
         }
     }
+    let slopes = bricks.len();
+
+    info!("Merging foundations");
+    let foundations = merge_foundations(
+        &mut bricks,
+        &layout,
+        colormap,
+        &floors,
+        &culled,
+        &depth_layers,
+        (width, height),
+        &progress_f,
+    )?;
 
     let area = width as usize * height as usize;
     info!(
@@ -460,7 +483,8 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
         counts[5],
     );
     info!(
-        "Converted {} pixel(s) to {} brick(s) ({:.2} per cell)",
+        "Converted {} pixel(s) to {} brick(s) ({:.2} per cell): {slopes} surface, {foundations} \
+         foundation",
         area,
         bricks.len(),
         bricks.len() as f64 / area.max(1) as f64,
@@ -470,57 +494,184 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
     Ok(bricks)
 }
 
-/// Emit one cell's assembly: the foundation prism, the load-bearing shape, and
-/// the triangle cap or complementary triangle where the fit calls for one.
-///
-/// `anchor` carries the cell's centre in X/Y and the altitude of its LOWEST
-/// surface vertex in Z -- what the geometry contract calls `base`.
-fn emit_cell(
-    out: &mut Vec<Brick>,
-    options: &GenOptions,
-    fit: CellFit,
-    anchor: Position,
+/// Where the terrain's cell grid sits in world units, and how bricks are
+/// styled. Bundled so the surface pass and the foundation pass cannot drift
+/// apart on the centring, the ground plane, or the material.
+struct Layout {
+    /// Half extent of one cell in X and Y, in units.
     half: i32,
+    /// Units per terrain layer. Even, and at least 2.
     rise_unit: i32,
-    depth: i32,
-    color: Color,
-) {
-    let mut piece = |asset, size: BrickSize, z: i32, turn: Turn| {
-        out.push(Brick {
+    offset_x: i32,
+    offset_y: i32,
+    /// World Z of the surface of layer zero.
+    z_floor: i32,
+    glow: bool,
+    collision: brdb::Collision,
+}
+
+impl Layout {
+    fn brick(
+        &self,
+        asset: brdb::BString,
+        size: BrickSize,
+        position: Position,
+        color: Color,
+        turn: Turn,
+    ) -> Brick {
+        Brick {
             asset: BrickType::Procedural { asset, size },
-            position: Position::new(anchor.x, anchor.y, z),
-            collision: options.collision(),
+            position,
+            collision: self.collision,
             color,
             owner_index: None,
             direction: Direction::ZPositive,
             rotation: turn.rotation(),
-            material_intensity: if options.glow { 0 } else { 5 },
-            material: if options.glow { GLOW } else { PLASTIC },
+            material_intensity: if self.glow { 0 } else { 5 },
+            material: if self.glow { GLOW } else { PLASTIC },
             ..Default::default()
-        });
+        }
+    }
+}
+
+/// Emit the foundation layer as as few boxes as the grid allows.
+///
+/// A foundation is a flat-topped prism, so the foundation layer is an ordinary
+/// 2D field of `(colour, top, depth)` and merges the way the blocky renderers
+/// merge their prisms. Without this the surface grammar's one-shape-per-cell
+/// rule leaked into the part of the build nobody can see: a flat plain cost one
+/// brick per PIXEL under `--terrain` while the same plain under `--micro` cost
+/// one brick for the whole region.
+///
+/// Cells join a box only when their colour, top AND depth all match exactly.
+/// Unifying mismatched depths to the deepest one would merge far more
+/// aggressively, but it also hangs solid material below where a shallower cell
+/// ended -- which is invisible on a plain and very visible from inside a
+/// canyon, where the cliff base is the thing being looked at.
+#[allow(clippy::too_many_arguments)]
+fn merge_foundations<F: Fn(f32) -> bool, D: Fn(u32, u32) -> i32>(
+    out: &mut Vec<Brick>,
+    layout: &Layout,
+    colormap: &dyn Colormap,
+    floors: &[i32],
+    culled: &[bool],
+    depth_layers: &D,
+    (width, height): (u32, u32),
+    progress_f: &F,
+) -> Result<usize, String> {
+    let mut taken = vec![false; width as usize * height as usize];
+    // A box may not exceed 500 units on any axis.
+    let max_run = (MAX_HALF_EXTENT / layout.half).max(1) as u32;
+    let mut emitted = 0usize;
+
+    let index = |x: u32, y: u32| y as usize * width as usize + x as usize;
+    let joins = |x: u32, y: u32, top: i32, depth: i32, color: [u8; 4], taken: &[bool]| {
+        let i = index(x, y);
+        !culled[i]
+            && !taken[i]
+            && floors[i] == top
+            && depth_layers(x, y) == depth
+            && colormap.at(x, y) == color
     };
 
-    // The foundation, top flush with `base`, split into 500-unit pieces because
-    // that is the tallest procedural brick the format can carry.
-    let mut remaining = depth.max(2);
-    let mut top = anchor.z;
-    while remaining > 0 {
-        let slab = remaining.min(MAX_HALF_EXTENT * 2);
-        piece(
-            PB_DEFAULT_MICRO_BRICK,
-            BrickSize::new(half as u16, half as u16, (slab / 2) as u16),
-            top - slab / 2,
-            Turn(0),
-        );
-        remaining -= slab;
-        top -= slab;
+    for y in 0..height {
+        for x in 0..width {
+            let i = index(x, y);
+            if culled[i] || taken[i] {
+                continue;
+            }
+            let top = floors[i];
+            let depth = depth_layers(x, y);
+            let color = colormap.at(x, y);
+
+            let mut run_x = 1;
+            while run_x < max_run
+                && x + run_x < width
+                && joins(x + run_x, y, top, depth, color, &taken)
+            {
+                run_x += 1;
+            }
+
+            let mut run_y = 1;
+            'rows: while run_y < max_run && y + run_y < height {
+                for dx in 0..run_x {
+                    if !joins(x + dx, y + run_y, top, depth, color, &taken) {
+                        // A partial row is discarded whole: the box has to stay
+                        // rectangular.
+                        break 'rows;
+                    }
+                }
+                run_y += 1;
+            }
+
+            for dy in 0..run_y {
+                for dx in 0..run_x {
+                    taken[index(x + dx, y + dy)] = true;
+                }
+            }
+
+            // Top flush with the cell floor, split into 500-unit slabs because
+            // that is the tallest procedural brick the format can carry.
+            let mut remaining = (depth * layout.rise_unit).max(2);
+            let mut top_units = layout.z_floor + top * layout.rise_unit;
+            while remaining > 0 {
+                let slab = remaining.min(MAX_HALF_EXTENT * 2);
+                out.push(layout.brick(
+                    PB_DEFAULT_MICRO_BRICK,
+                    BrickSize::new(
+                        (run_x as i32 * layout.half) as u16,
+                        (run_y as i32 * layout.half) as u16,
+                        (slab / 2) as u16,
+                    ),
+                    Position::new(
+                        (x as i32 * 2 + run_x as i32) * layout.half + layout.offset_x,
+                        (y as i32 * 2 + run_y as i32) * layout.half + layout.offset_y,
+                        top_units - slab / 2,
+                    ),
+                    Color {
+                        r: color[0],
+                        g: color[1],
+                        b: color[2],
+                    },
+                    Turn(0),
+                ));
+                emitted += 1;
+                remaining -= slab;
+                top_units -= slab;
+            }
+        }
+        if y % 32 == 0 && !progress_f(0.85 + 0.1 * (y as f32 / height as f32)) {
+            return Err("Stopped by user".to_string());
+        }
     }
+    Ok(emitted)
+}
+
+/// Emit one cell's SURFACE: the load-bearing shape, plus the triangle cap or
+/// complementary triangle where the fit calls for one. The foundation under it
+/// is not emitted here -- foundations are flat-topped prisms and merge across
+/// cells, so [`merge_foundations`] lays the whole layer at once.
+///
+/// `anchor` carries the cell's centre in X/Y and the altitude of its LOWEST
+/// surface vertex in Z -- what the geometry contract calls `base`. A flat cell
+/// emits nothing at all: its foundation's top face IS its surface.
+fn emit_slope(out: &mut Vec<Brick>, layout: &Layout, fit: CellFit, anchor: Position, color: Color) {
+    let half = layout.half as u16;
+    let mut piece = |asset, size: BrickSize, z: i32, turn: Turn| {
+        out.push(layout.brick(
+            asset,
+            size,
+            Position::new(anchor.x, anchor.y, z),
+            color,
+            turn,
+        ));
+    };
 
     // A rise is CLAMPED, never rounded up: raising it would push the surface
     // above a sampled vertex and break the fit-from-below guarantee that keeps
     // one cell from protruding through its neighbour.
-    let rise = (fit.rise * rise_unit).min(MAX_HALF_EXTENT * 2);
-    let cap = (fit.cap_rise * rise_unit).min(MAX_HALF_EXTENT * 2);
+    let rise = (fit.rise * layout.rise_unit).min(MAX_HALF_EXTENT * 2);
+    let cap = (fit.cap_rise * layout.rise_unit).min(MAX_HALF_EXTENT * 2);
     let (asset, turn, second) = match fit.kind {
         SurfaceKind::Flat => return,
         SurfaceKind::Ramp(t) => (PB_DEFAULT_MICRO_RAMP, t, None),
@@ -543,7 +694,7 @@ fn emit_cell(
     }
     piece(
         asset,
-        BrickSize::new(half as u16, half as u16, (rise / 2) as u16),
+        BrickSize::new(half, half, (rise / 2) as u16),
         anchor.z + rise / 2,
         turn,
     );
@@ -556,7 +707,7 @@ fn emit_cell(
         // independently, from the middle level to the top one.
         SurfaceKind::OuterTriangle(_) if cap >= 2 => piece(
             PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
-            BrickSize::new(half as u16, half as u16, (cap / 2) as u16),
+            BrickSize::new(half, half, (cap / 2) as u16),
             anchor.z + rise + cap / 2,
             second_turn,
         ),
@@ -564,7 +715,7 @@ fn emit_cell(
         // their rotations differ, and together they tile the square.
         SurfaceKind::TrianglePair(_) => piece(
             PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
-            BrickSize::new(half as u16, half as u16, (rise / 2) as u16),
+            BrickSize::new(half, half, (rise / 2) as u16),
             anchor.z + rise / 2,
             second_turn,
         ),
@@ -761,6 +912,169 @@ mod tests {
             representable > 40,
             "the sweep must actually cover the grammar"
         );
+    }
+
+    /// A constant-height, constant-colour heightmap, for exercising the
+    /// foundation merge against the case it exists for.
+    struct Flat(u32, u32, u32);
+    impl Heightmap for Flat {
+        fn at(&self, _x: u32, _y: u32) -> u32 {
+            self.2
+        }
+        fn size(&self) -> (u32, u32) {
+            (self.0, self.1)
+        }
+    }
+    /// A height field with one step across the middle, so foundations have two
+    /// different depths and must not merge across the break.
+    struct Step(u32, u32);
+    impl Heightmap for Step {
+        fn at(&self, x: u32, _y: u32) -> u32 {
+            if x < self.0 / 2 { 0 } else { 8 }
+        }
+        fn size(&self) -> (u32, u32) {
+            (self.0, self.1)
+        }
+    }
+    struct Grey(u32, u32);
+    impl Colormap for Grey {
+        fn at(&self, _x: u32, _y: u32) -> [u8; 4] {
+            [128, 128, 128, 255]
+        }
+        fn size(&self) -> (u32, u32) {
+            (self.0, self.1)
+        }
+    }
+    /// One distinct colour per pixel: nothing may merge.
+    struct Rainbow(u32, u32);
+    impl Colormap for Rainbow {
+        fn at(&self, x: u32, y: u32) -> [u8; 4] {
+            [x as u8, y as u8, (x ^ y) as u8, 255]
+        }
+        fn size(&self) -> (u32, u32) {
+            (self.0, self.1)
+        }
+    }
+
+    fn options() -> GenOptions {
+        GenOptions {
+            size: 5,
+            scale: 2,
+            asset: PB_DEFAULT_MICRO_BRICK,
+            cull: false,
+            micro: false,
+            stud: false,
+            snap: false,
+            img: false,
+            glow: false,
+            hdmap: false,
+            lrgb: false,
+            nocollide: false,
+            quadtree: true,
+            greedy: false,
+            surface: SurfaceMode::Terrain,
+        }
+    }
+
+    /// The whole point of the merge pass: a flat plain is one flat-topped
+    /// prism, not one per pixel. Before it existed this render cost 1024
+    /// bricks.
+    #[test]
+    fn a_uniform_plain_collapses_to_a_handful_of_foundation_boxes() {
+        let bricks =
+            gen_terrain_heightmap(&Flat(32, 32, 4), &Grey(32, 32), options(), |_| true).unwrap();
+        assert!(
+            bricks.len() < 8,
+            "1024 identical cells collapsed to only {} brick(s)",
+            bricks.len()
+        );
+        // ...and it really is flat, so nothing paid for a wedge either.
+        assert!(bricks.iter().all(|b| {
+            let BrickType::Procedural { asset, .. } = &b.asset else {
+                unreachable!()
+            };
+            asset.as_ref() == "PB_DefaultMicroBrick"
+        }));
+    }
+
+    /// The merge must be driven by the field, not by luck: a colormap with a
+    /// different colour on every pixel has nothing to merge, and must still
+    /// cover every cell.
+    #[test]
+    fn a_per_pixel_colormap_merges_nothing_and_still_covers_every_cell() {
+        let bricks =
+            gen_terrain_heightmap(&Flat(16, 16, 4), &Rainbow(16, 16), options(), |_| true).unwrap();
+        assert_eq!(
+            bricks.len(),
+            256,
+            "distinct colours cannot share a box, so every cell needs its own"
+        );
+    }
+
+    /// Foundations of different depths must not join. A box spanning the step
+    /// would either leave the cliff face open or hang material below the low
+    /// side.
+    #[test]
+    fn foundations_never_merge_across_a_change_in_depth() {
+        let bricks =
+            gen_terrain_heightmap(&Step(16, 16), &Grey(16, 16), options(), |_| true).unwrap();
+        let cell = 10; // options().size is a half extent, so a cell is 10 units
+        let left_edge = -(16 * 5);
+        // No foundation may straddle the seam at the middle of the map.
+        let seam = left_edge + 8 * cell;
+        for brick in &bricks {
+            let BrickType::Procedural { asset, size } = &brick.asset else {
+                unreachable!()
+            };
+            if asset.as_ref() != "PB_DefaultMicroBrick" {
+                continue;
+            }
+            let low = brick.position.x - size.x as i32;
+            let high = brick.position.x + size.x as i32;
+            assert!(
+                low >= seam || high <= seam,
+                "a foundation spans the step from {low} to {high} (seam at {seam})"
+            );
+        }
+    }
+
+    /// The merge is an optimization, so it must not change what is solid. Every
+    /// cell's foundation column has to come back covered, exactly once, from
+    /// its own top down to its own depth.
+    #[test]
+    fn merging_covers_the_same_volume_one_cell_at_a_time_would_have() {
+        let bricks =
+            gen_terrain_heightmap(&Step(12, 12), &Grey(12, 12), options(), |_| true).unwrap();
+        let cell = 10;
+        let origin = -(12 * 5);
+        let mut covered = std::collections::HashMap::<(i32, i32), (i32, i32)>::new();
+        for brick in &bricks {
+            let BrickType::Procedural { asset, size } = &brick.asset else {
+                unreachable!()
+            };
+            if asset.as_ref() != "PB_DefaultMicroBrick" {
+                continue;
+            }
+            let x0 = (brick.position.x - size.x as i32 - origin) / cell;
+            let y0 = (brick.position.y - size.y as i32 - origin) / cell;
+            for dx in 0..(size.x as i32 * 2 / cell) {
+                for dy in 0..(size.y as i32 * 2 / cell) {
+                    let span = (
+                        brick.position.z - size.z as i32,
+                        brick.position.z + size.z as i32,
+                    );
+                    let entry = covered.entry((x0 + dx, y0 + dy)).or_insert(span);
+                    *entry = (entry.0.min(span.0), entry.1.max(span.1));
+                }
+            }
+        }
+        assert_eq!(covered.len(), 144, "every cell must carry a foundation");
+        // A uniform half of the map is one depth and the other half another, so
+        // both cases are represented; what matters is that each column is a
+        // single contiguous span reaching its own surface.
+        for ((x, y), (low, high)) in &covered {
+            assert!(high > low, "cell ({x}, {y}) has an empty foundation");
+        }
     }
 
     #[test]

--- a/src/opt/terrain.rs
+++ b/src/opt/terrain.rs
@@ -1,0 +1,773 @@
+//! Smooth micro-brick terrain.
+//!
+//! The blocky renderers ([`super::gen_quad_heightmap`],
+//! [`super::gen_greedy_heightmap`]) give every pixel a flat top, so a slope
+//! comes out as a staircase. This one gives every pixel a SLOPED top, chosen
+//! from Brickadia's micro wedge family, so a smooth height field renders as a
+//! smooth surface.
+//!
+//! The geometry contract is the measured one from the `terrain-experiment`
+//! prefab generator (`docs/MICRO_TERRAIN_GEOMETRY.md`), derived by correlating
+//! an in-game GLB export against the same ordered `.brz` through BRDB. The
+//! facts this module depends on, restated so it can be read on its own:
+//!
+//! * Brickadia stores 10 position units per stud, and a procedural brick's
+//!   `BrickSize` components are HALF extents. A shape with `z = k` is `2k`
+//!   units tall, so any rise this module emits must be even.
+//! * Heights are sampled on a SHARED VERTEX grid, not per pixel. Two
+//!   neighbouring cells quote the same vertex, which is what makes their
+//!   surfaces meet instead of merely coming close.
+//! * With `Direction::ZPositive` and `Rotation::Deg0`, and corners read in
+//!   `(SW, SE, NE, NW)` order (i.e. `(-X,-Y)`, `(+X,-Y)`, `(+X,+Y)`,
+//!   `(-X,+Y)`):
+//!
+//!   | asset | surface |
+//!   | --- | --- |
+//!   | `PB_DefaultMicroBrick` | `(1,1,1,1)`, flat top |
+//!   | `PB_DefaultMicroRamp` | low toward `+X` |
+//!   | `PB_DefaultMicroWedgeCorner` | high vertex at SW |
+//!   | `PB_DefaultMicroWedgeInnerCorner` | low vertex at NE |
+//!   | `PB_DefaultMicroWedgeOuterCorner` | low vertex at NE |
+//!   | `PB_DefaultMicroWedgeTriangleCorner` | SW triangle, high at SW |
+//!
+//! * A flat micro brick is centred at `base - half_height`, so its TOP is at
+//!   `base`. A sloped shape is centred at `base + half_rise`, so its low
+//!   vertices are at `base` and its high ones at `base + rise`.
+//!
+//! **Every cell goes through the same best-fit selection.** `terrain-experiment`
+//! reserved that for "wall cells" and used a plain pattern match elsewhere;
+//! here it is the only path, because a heightmap is not a slope-limited field.
+//! A cliff, a one-pixel spike and a gentle dune all arrive as four corner
+//! altitudes, and the fit enumerates every assembly the grammar can express,
+//! scores each by its total deviation from those four, and takes the best.
+//!
+//! Candidates are always fitted FROM BELOW -- each partition takes the MINIMUM
+//! of the corners it covers, never their mean -- so the chosen surface sits at
+//! or below every sampled vertex and can never protrude through the
+//! neighbouring tile. A clean two-level fault therefore becomes one exact steep
+//! ramp meeting the plain and the plateau flush, rather than a shelf stuck onto
+//! the cliff.
+
+use crate::map::*;
+use crate::util::*;
+use brdb::{
+    Brick, BrickSize, BrickType, Color, Direction, Position, Rotation,
+    assets::{
+        bricks::{
+            PB_DEFAULT_MICRO_BRICK, PB_DEFAULT_MICRO_RAMP, PB_DEFAULT_MICRO_WEDGE_CORNER,
+            PB_DEFAULT_MICRO_WEDGE_INNER_CORNER, PB_DEFAULT_MICRO_WEDGE_OUTER_CORNER,
+            PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
+        },
+        materials::{GLOW, PLASTIC},
+    },
+};
+use log::info;
+
+/// The largest half extent a procedural brick may carry, i.e. a 500-unit
+/// piece. A taller rise is split (foundations) or clamped down (slopes); it is
+/// never rounded UP, because that would push the surface above a sampled
+/// vertex and undo the fit-from-below guarantee.
+const MAX_HALF_EXTENT: i32 = 250;
+
+/// One cell's four corner heights, in the `(SW, SE, NE, NW)` order the whole
+/// grammar is calibrated in.
+pub type Corners = [i32; 4];
+
+/// Quarter turns counter-clockwise around `+Z`.
+///
+/// The grammar is compared and asserted on constantly -- fits are scored
+/// against each other, and every rotation convention below is pinned by a test
+/// -- and `brdb::Rotation` carries no `PartialEq`. This is that enum with an
+/// equality, converted at emission.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Turn(pub u8);
+
+impl Turn {
+    fn new(turns: i32) -> Self {
+        Self(turns.rem_euclid(4) as u8)
+    }
+
+    /// The half turn that pairs with this one, for the two complementary
+    /// triangles of a [`SurfaceKind::TrianglePair`].
+    fn opposite(self) -> Self {
+        Self((self.0 + 2) % 4)
+    }
+
+    fn rotation(self) -> Rotation {
+        match self.0 {
+            0 => Rotation::Deg0,
+            1 => Rotation::Deg90,
+            2 => Rotation::Deg180,
+            _ => Rotation::Deg270,
+        }
+    }
+}
+
+/// Which assembly a cell resolves to. The `Turn` is already in Brickadia's own
+/// convention -- see the table in the module doc for what rotation zero means
+/// for each asset.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SurfaceKind {
+    /// One flat micro brick, top at `base`.
+    Flat,
+    /// `PB_DefaultMicroRamp`: two adjacent corners high.
+    Ramp(Turn),
+    /// `PB_DefaultMicroWedgeCorner`: exactly one corner high.
+    Corner(Turn),
+    /// `PB_DefaultMicroWedgeInnerCorner`: exactly one corner low.
+    InnerCorner(Turn),
+    /// `PB_DefaultMicroWedgeOuterCorner` plus a `...TriangleCorner` one rise
+    /// above it: the diagonal `0,1,2,1` stack. Reducing this to a two-level
+    /// mask loses the upper triangle and leaves a visible step.
+    OuterTriangle(Turn),
+    /// Two complementary `PB_DefaultMicroWedgeTriangleCorner`s covering the
+    /// whole square: opposite corners high.
+    TrianglePair(Turn),
+}
+
+impl SurfaceKind {
+    /// How many bricks this assembly emits, foundation excluded. Used to break
+    /// ties between fits that deviate from the sampled corners equally: the
+    /// cheaper one wins, so a cell that a flat brick describes exactly never
+    /// spends a wedge on it.
+    pub fn brick_count(self) -> u32 {
+        match self {
+            SurfaceKind::Flat => 1,
+            SurfaceKind::Ramp(_) | SurfaceKind::Corner(_) | SurfaceKind::InnerCorner(_) => 1,
+            SurfaceKind::OuterTriangle(_) | SurfaceKind::TrianglePair(_) => 2,
+        }
+    }
+}
+
+/// The chosen assembly for one cell, with the heights it actually fits.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct CellFit {
+    pub kind: SurfaceKind,
+    /// Height of the assembly's LOWEST surface vertex, in layers.
+    pub base: i32,
+    /// Rise of the load-bearing shape above `base`, in layers. Zero for
+    /// [`SurfaceKind::Flat`].
+    pub rise: i32,
+    /// Rise of the triangle cap above `base + rise`, in layers.
+    /// [`SurfaceKind::OuterTriangle`] only.
+    pub cap_rise: i32,
+    /// Total `sampled - fitted` over the four corners, in layers. Always
+    /// non-negative: every candidate is fitted from below.
+    pub error: i32,
+}
+
+/// Turn putting a shape's HIGH vertex at `corner`. Rotation zero is high at SW
+/// for both `MicroWedgeCorner` and `MicroWedgeTriangleCorner`, so the mapping
+/// is the identity: `SW/SE/NE/NW -> 0/90/180/270`.
+fn turn_from_high_corner(corner: usize) -> Turn {
+    Turn::new(corner as i32)
+}
+
+/// Turn putting a shape's LOW vertex at `corner`. Rotation zero is low at NE
+/// for both inner and outer corners, so the mapping is a half turn away from
+/// [`turn_from_high_corner`]: `low SW/SE/NE/NW -> 180/270/0/90`.
+fn turn_from_low_corner(corner: usize) -> Turn {
+    Turn::new(corner as i32 + 2)
+}
+
+/// Choose the assembly whose surface best matches four sampled corner heights.
+///
+/// Enumerates the whole grammar -- flat, all fourteen two-level high/low
+/// partitions (which map onto ramp, corner, inner corner and triangle pair),
+/// and the four diagonal `0,1,2,1` stacks -- and scores each by the total
+/// height it leaves on the table. Every candidate is fitted FROM BELOW, so its
+/// score is a sum of non-negative residuals and the winning surface never rises
+/// above a sampled vertex.
+///
+/// Ties go to the assembly using fewer bricks, which is what keeps a flat
+/// region flat rather than paving it in zero-rise wedges.
+pub fn fit_cell(corners: Corners) -> CellFit {
+    let floor = *corners.iter().min().expect("four corners");
+    let mut best = CellFit {
+        kind: SurfaceKind::Flat,
+        base: floor,
+        rise: 0,
+        cap_rise: 0,
+        error: corners.iter().map(|c| c - floor).sum(),
+    };
+
+    let mut consider = |candidate: CellFit| {
+        let better = candidate.error < best.error
+            || (candidate.error == best.error
+                && candidate.kind.brick_count() < best.kind.brick_count());
+        if better {
+            best = candidate;
+        }
+    };
+
+    // The fourteen two-level partitions. Bit `i` set means corner `i` is on the
+    // high level; 0 and 15 are the flat case already seeded above.
+    for mask in 1u8..15 {
+        let high = |i: usize| mask >> i & 1 == 1;
+        let low_level = (0..4)
+            .filter(|i| !high(*i))
+            .map(|i| corners[i])
+            .min()
+            .expect("a partition in 1..15 has a low corner");
+        let high_level = (0..4)
+            .filter(|i| high(*i))
+            .map(|i| corners[i])
+            .min()
+            .expect("a partition in 1..15 has a high corner");
+        let rise = high_level - low_level;
+        if rise <= 0 {
+            // Degenerate: the "high" level is not above the low one, so this
+            // partition describes the flat surface already considered.
+            continue;
+        }
+        let error = (0..4)
+            .map(|i| corners[i] - if high(i) { low_level + rise } else { low_level })
+            .sum();
+        let kind = match mask {
+            // One raised vertex: a convex shoulder.
+            1 | 2 | 4 | 8 => {
+                SurfaceKind::Corner(turn_from_high_corner(mask.trailing_zeros() as usize))
+            }
+            // One low vertex: the concave transition. The OUTER corner has the
+            // same edge heights but the opposite internal triangulation and is
+            // reserved for the stacked diagonal case below, where its triangle
+            // cap completes the surface.
+            7 | 11 | 13 | 14 => SurfaceKind::InnerCorner(turn_from_low_corner(
+                (!mask & 15).trailing_zeros() as usize,
+            )),
+            // Opposite highs: two complementary triangles cover the square and
+            // preserve all four sampled corners.
+            5 => SurfaceKind::TrianglePair(Turn(0)),
+            10 => SurfaceKind::TrianglePair(Turn(1)),
+            // Adjacent highs: a cardinal ramp, named by which way it steps
+            // DOWN. Rotation zero is low toward +X.
+            9 => SurfaceKind::Ramp(Turn(0)),  // low NE+SE, i.e. +X
+            3 => SurfaceKind::Ramp(Turn(1)),  // low NE+NW, i.e. +Y
+            6 => SurfaceKind::Ramp(Turn(2)),  // low SW+NW, i.e. -X
+            12 => SurfaceKind::Ramp(Turn(3)), // low SW+SE, i.e. -Y
+            _ => unreachable!("every mask in 1..15 is covered"),
+        };
+        consider(CellFit {
+            kind,
+            base: low_level,
+            rise,
+            cap_rise: 0,
+            error,
+        });
+    }
+
+    // The four diagonal stacks: one corner two rises up, the corner opposite it
+    // at the bottom, and the two between them in the middle. An orthogonal
+    // one-step limit does not prevent this, and collapsing it to a two-level
+    // mask is exactly what produces the broken transitions seen in game.
+    for high in 0..4 {
+        let bottom = corners[(high + 2) & 3];
+        let middle = corners[(high + 1) & 3].min(corners[(high + 3) & 3]);
+        let top = corners[high];
+        let rise = middle - bottom;
+        let cap_rise = top - middle;
+        if rise <= 0 || cap_rise <= 0 {
+            continue;
+        }
+        consider(CellFit {
+            kind: SurfaceKind::OuterTriangle(turn_from_high_corner(high)),
+            base: bottom,
+            rise,
+            cap_rise,
+            // The bottom and top corners are matched exactly; only the two
+            // middle ones can differ, and only by however far apart they are.
+            error: (corners[(high + 1) & 3] - middle) + (corners[(high + 3) & 3] - middle),
+        });
+    }
+
+    best
+}
+
+/// Generate smooth micro-wedge terrain from a heightmap.
+///
+/// Heights are read on a shared `(w+1) x (h+1)` vertex grid: vertex `(i, j)` is
+/// the mean of the up-to-four pixels touching it. That keeps the output exactly
+/// one cell per pixel -- the same footprint every other mode produces -- while
+/// giving neighbouring cells the shared corner heights the grammar needs, and
+/// it costs one bilinear smoothing pass that a heightmap generally wants
+/// anyway.
+///
+/// Under `--terrain` the vertical scale is a LAYER height rather than a raw
+/// unit count: one shade of grey is one layer, `rise_unit` units tall. It is
+/// rounded up to an even number and floored at 2 because a wedge's `BrickSize`
+/// half height must be a whole unit.
+pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
+    heightmap: &dyn Heightmap,
+    colormap: &dyn Colormap,
+    options: GenOptions,
+    progress_f: F,
+) -> Result<Vec<Brick>, String> {
+    macro_rules! progress {
+        ($e:expr) => {
+            if !progress_f($e) {
+                return Err("Stopped by user".to_string());
+            }
+        };
+    }
+    progress!(0.0);
+
+    let (width, height) = heightmap.size();
+    if colormap.size() != (width, height) {
+        return Err("Heightmap and colormap must have same dimensions".to_string());
+    }
+    if width == 0 || height == 0 {
+        return Err("Heightmap is empty".to_string());
+    }
+
+    // Rounded UP to even, floored at 2: a rise of `rise_unit` units is emitted
+    // as a `BrickSize` half height of `rise_unit / 2`, which must be a whole
+    // unit and must not be zero.
+    let scale = options.scale.max(1) as i32;
+    let rise_unit = scale + (scale & 1);
+    if rise_unit != scale {
+        info!(
+            "Terrain layers are {rise_unit} units tall (--vertical {scale} rounded up: a micro \
+             wedge's half height must be a whole unit)"
+        );
+    }
+    let half = options.size as i32;
+
+    info!("Sampling shared vertex grid");
+    let stride = width as usize + 1;
+    let mut vertices = vec![0i32; stride * (height as usize + 1)];
+    for j in 0..=height {
+        for i in 0..=width {
+            let mut sum = 0i64;
+            let mut count = 0i64;
+            for (dx, dy) in [(-1i32, -1i32), (0, -1), (-1, 0), (0, 0)] {
+                let px = i as i32 + dx;
+                let py = j as i32 + dy;
+                if px >= 0 && py >= 0 && (px as u32) < width && (py as u32) < height {
+                    sum += heightmap.at(px as u32, py as u32).min(i32::MAX as u32) as i64;
+                    count += 1;
+                }
+            }
+            vertices[j as usize * stride + i as usize] = ((sum + count / 2) / count) as i32;
+        }
+    }
+    progress!(0.2);
+
+    let corners_at = |x: u32, y: u32| -> Corners {
+        let (x, y) = (x as usize, y as usize);
+        [
+            vertices[y * stride + x],
+            vertices[y * stride + x + 1],
+            vertices[(y + 1) * stride + x + 1],
+            vertices[(y + 1) * stride + x],
+        ]
+    };
+
+    // Pass one records only each cell's floor, which is all the foundation
+    // depths below need. Keeping the fits themselves would cost five times the
+    // memory on a map where a full brick list is already the binding limit.
+    info!("Classifying cells");
+    let mut floors = vec![0i32; width as usize * height as usize];
+    let mut culled = vec![false; width as usize * height as usize];
+    for y in 0..height {
+        for x in 0..width {
+            let index = y as usize * width as usize + x as usize;
+            let color = colormap.at(x, y);
+            // Same rule the blocky modes use: with --cull, a fully transparent
+            // pixel and a bottom-level pixel are both dropped.
+            culled[index] = options.cull && (heightmap.at(x, y) == 0 || color[3] == 0);
+            floors[index] = *corners_at(x, y).iter().min().expect("four corners");
+        }
+        if y % 64 == 0 {
+            progress!(0.2 + 0.3 * (y as f32 / height as f32));
+        }
+    }
+    progress!(0.5);
+
+    info!("Building terrain assemblies");
+    // Centred exactly as the blocky modes centre their output, so switching
+    // modes does not move the build.
+    let offset_x = -(width as i32 * half);
+    let offset_y = -(height as i32 * half);
+    // Surface of layer zero, matching where the blocky modes put the top of a
+    // zero-height cell.
+    let z_floor = options.base_height() - 5;
+
+    let mut bricks: Vec<Brick> = Vec::new();
+    let mut counts = [0usize; 6];
+    for y in 0..height {
+        for x in 0..width {
+            let index = y as usize * width as usize + x as usize;
+            if culled[index] {
+                continue;
+            }
+            let fit = fit_cell(corners_at(x, y));
+            counts[match fit.kind {
+                SurfaceKind::Flat => 0,
+                SurfaceKind::Ramp(_) => 1,
+                SurfaceKind::Corner(_) => 2,
+                SurfaceKind::InnerCorner(_) => 3,
+                SurfaceKind::OuterTriangle(_) => 4,
+                SurfaceKind::TrianglePair(_) => 5,
+            }] += 1;
+
+            // The foundation reaches below the lowest neighbouring floor, which
+            // is what closes a cliff face from the high side. `+ 1` layer keeps
+            // a flat plain one layer thick instead of zero.
+            let mut lowest = floors[index];
+            for (dx, dy) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+                let nx = x as i32 + dx;
+                let ny = y as i32 + dy;
+                if nx >= 0 && ny >= 0 && (nx as u32) < width && (ny as u32) < height {
+                    lowest = lowest.min(floors[ny as usize * width as usize + nx as usize]);
+                }
+            }
+            let depth = ((floors[index] - lowest).max(0) + 1) * rise_unit;
+
+            let color = colormap.at(x, y);
+            emit_cell(
+                &mut bricks,
+                &options,
+                fit,
+                Position::new(
+                    (x as i32 * 2 + 1) * half + offset_x,
+                    (y as i32 * 2 + 1) * half + offset_y,
+                    z_floor + fit.base * rise_unit,
+                ),
+                half,
+                rise_unit,
+                depth,
+                Color {
+                    r: color[0],
+                    g: color[1],
+                    b: color[2],
+                },
+            );
+        }
+        if y % 32 == 0 {
+            progress!(0.5 + 0.45 * (y as f32 / height as f32));
+        }
+    }
+
+    let area = width as usize * height as usize;
+    info!(
+        "Fitted {} cell(s): {} flat, {} ramp, {} corner, {} inner corner, {} diagonal stack, {} triangle pair",
+        counts.iter().sum::<usize>(),
+        counts[0],
+        counts[1],
+        counts[2],
+        counts[3],
+        counts[4],
+        counts[5],
+    );
+    info!(
+        "Converted {} pixel(s) to {} brick(s) ({:.2} per cell)",
+        area,
+        bricks.len(),
+        bricks.len() as f64 / area.max(1) as f64,
+    );
+
+    progress!(1.0);
+    Ok(bricks)
+}
+
+/// Emit one cell's assembly: the foundation prism, the load-bearing shape, and
+/// the triangle cap or complementary triangle where the fit calls for one.
+///
+/// `anchor` carries the cell's centre in X/Y and the altitude of its LOWEST
+/// surface vertex in Z -- what the geometry contract calls `base`.
+fn emit_cell(
+    out: &mut Vec<Brick>,
+    options: &GenOptions,
+    fit: CellFit,
+    anchor: Position,
+    half: i32,
+    rise_unit: i32,
+    depth: i32,
+    color: Color,
+) {
+    let mut piece = |asset, size: BrickSize, z: i32, turn: Turn| {
+        out.push(Brick {
+            asset: BrickType::Procedural { asset, size },
+            position: Position::new(anchor.x, anchor.y, z),
+            collision: options.collision(),
+            color,
+            owner_index: None,
+            direction: Direction::ZPositive,
+            rotation: turn.rotation(),
+            material_intensity: if options.glow { 0 } else { 5 },
+            material: if options.glow { GLOW } else { PLASTIC },
+            ..Default::default()
+        });
+    };
+
+    // The foundation, top flush with `base`, split into 500-unit pieces because
+    // that is the tallest procedural brick the format can carry.
+    let mut remaining = depth.max(2);
+    let mut top = anchor.z;
+    while remaining > 0 {
+        let slab = remaining.min(MAX_HALF_EXTENT * 2);
+        piece(
+            PB_DEFAULT_MICRO_BRICK,
+            BrickSize::new(half as u16, half as u16, (slab / 2) as u16),
+            top - slab / 2,
+            Turn(0),
+        );
+        remaining -= slab;
+        top -= slab;
+    }
+
+    // A rise is CLAMPED, never rounded up: raising it would push the surface
+    // above a sampled vertex and break the fit-from-below guarantee that keeps
+    // one cell from protruding through its neighbour.
+    let rise = (fit.rise * rise_unit).min(MAX_HALF_EXTENT * 2);
+    let cap = (fit.cap_rise * rise_unit).min(MAX_HALF_EXTENT * 2);
+    let (asset, turn, second) = match fit.kind {
+        SurfaceKind::Flat => return,
+        SurfaceKind::Ramp(t) => (PB_DEFAULT_MICRO_RAMP, t, None),
+        SurfaceKind::Corner(t) => (PB_DEFAULT_MICRO_WEDGE_CORNER, t, None),
+        SurfaceKind::InnerCorner(t) => (PB_DEFAULT_MICRO_WEDGE_INNER_CORNER, t, None),
+        // The cap shares the outer corner's rotation: the outer corner is low
+        // at NE under rotation zero and the triangle is high at SW, which are
+        // the same quarter turn away from the cell's high vertex.
+        SurfaceKind::OuterTriangle(t) => (PB_DEFAULT_MICRO_WEDGE_OUTER_CORNER, t, Some(t)),
+        SurfaceKind::TrianglePair(t) => (
+            PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
+            t,
+            Some(t.opposite()),
+        ),
+    };
+    if rise < 2 {
+        // The whole rise vanished under the layer quantization; the foundation
+        // already covers this cell as a flat top.
+        return;
+    }
+    piece(
+        asset,
+        BrickSize::new(half as u16, half as u16, (rise / 2) as u16),
+        anchor.z + rise / 2,
+        turn,
+    );
+
+    let Some(second_turn) = second else {
+        return;
+    };
+    match fit.kind {
+        // The cap of a diagonal stack sits one full rise higher and is sized
+        // independently, from the middle level to the top one.
+        SurfaceKind::OuterTriangle(_) if cap >= 2 => piece(
+            PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
+            BrickSize::new(half as u16, half as u16, (cap / 2) as u16),
+            anchor.z + rise + cap / 2,
+            second_turn,
+        ),
+        // The two triangles of a pair are the same size in the same place; only
+        // their rotations differ, and together they tile the square.
+        SurfaceKind::TrianglePair(_) => piece(
+            PB_DEFAULT_MICRO_WEDGE_TRIANGLE_CORNER,
+            BrickSize::new(half as u16, half as u16, (rise / 2) as u16),
+            anchor.z + rise / 2,
+            second_turn,
+        ),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Corners are `(SW, SE, NE, NW)`.
+    const SW: usize = 0;
+    const SE: usize = 1;
+    const NE: usize = 2;
+    const NW: usize = 3;
+
+    #[test]
+    fn a_level_cell_is_one_flat_brick_with_no_residual() {
+        let fit = fit_cell([7, 7, 7, 7]);
+        assert_eq!(fit.kind, SurfaceKind::Flat);
+        assert_eq!((fit.base, fit.rise, fit.error), (7, 0, 0));
+    }
+
+    /// Rotation zero steps DOWN toward `+X`, so a cell high on its `-X` edge
+    /// (SW and NW) is the rotation-zero ramp. Each quarter turn moves the low
+    /// edge counter-clockwise.
+    #[test]
+    fn ramps_face_the_way_the_cell_steps_down() {
+        for (corners, expected) in [
+            ([1, 0, 0, 1], Turn(0)), // low toward +X
+            ([1, 1, 0, 0], Turn(1)), // low toward +Y
+            ([0, 1, 1, 0], Turn(2)), // low toward -X
+            ([0, 0, 1, 1], Turn(3)), // low toward -Y
+        ] {
+            let fit = fit_cell(corners);
+            assert_eq!(
+                fit.kind,
+                SurfaceKind::Ramp(expected),
+                "corners {corners:?} must ramp down the opposite way from its high edge"
+            );
+            assert_eq!((fit.base, fit.rise, fit.error), (0, 1, 0));
+        }
+    }
+
+    /// A single raised vertex is a full wedge corner, and rotation zero puts
+    /// the high point at SW.
+    #[test]
+    fn one_high_vertex_is_a_wedge_corner_rotated_onto_it() {
+        for corner in [SW, SE, NE, NW] {
+            let mut corners = [0; 4];
+            corners[corner] = 1;
+            let fit = fit_cell(corners);
+            assert_eq!(
+                fit.kind,
+                SurfaceKind::Corner(Turn::new(corner as i32)),
+                "a high {corner} must rotate the corner's SW high point onto it"
+            );
+            assert_eq!(fit.error, 0, "a one-high cell is exactly representable");
+        }
+    }
+
+    /// A single LOW vertex is the inner corner, whose rotation zero is low at
+    /// NE -- a half turn away from the wedge corner's convention.
+    #[test]
+    fn one_low_vertex_is_an_inner_corner_a_half_turn_from_the_high_convention() {
+        for corner in [SW, SE, NE, NW] {
+            let mut corners = [1; 4];
+            corners[corner] = 0;
+            let fit = fit_cell(corners);
+            assert_eq!(
+                fit.kind,
+                SurfaceKind::InnerCorner(Turn::new(corner as i32 + 2)),
+                "a low {corner} must rotate the inner corner's NE low point onto it"
+            );
+            assert_eq!(fit.error, 0);
+        }
+    }
+
+    #[test]
+    fn opposite_high_vertices_become_a_complementary_triangle_pair() {
+        assert_eq!(
+            fit_cell([1, 0, 1, 0]).kind,
+            SurfaceKind::TrianglePair(Turn(0))
+        );
+        assert_eq!(
+            fit_cell([0, 1, 0, 1]).kind,
+            SurfaceKind::TrianglePair(Turn(1))
+        );
+        // The two triangles must be half a turn apart, or they would overlap on
+        // one diagonal and leave the other uncovered.
+        let SurfaceKind::TrianglePair(turn) = fit_cell([1, 0, 1, 0]).kind else {
+            panic!("opposite highs are a triangle pair");
+        };
+        assert_eq!((turn.opposite().0 + 4 - turn.0) % 4, 2);
+    }
+
+    /// The row the geometry contract calls essential: an orthogonal one-step
+    /// limit does NOT stop opposite corners differing by two, and reducing that
+    /// case to a two-level mask loses the upper triangle.
+    #[test]
+    fn a_diagonal_two_layer_cell_stacks_a_triangle_on_an_outer_corner() {
+        for high in [SW, SE, NE, NW] {
+            let mut corners = [1; 4];
+            corners[high] = 2;
+            corners[(high + 2) & 3] = 0;
+            let fit = fit_cell(corners);
+            assert_eq!(
+                fit.kind,
+                SurfaceKind::OuterTriangle(Turn::new(high as i32)),
+                "corners {corners:?} need the diagonal stack, not a flattened mask"
+            );
+            assert_eq!((fit.base, fit.rise, fit.cap_rise, fit.error), (0, 1, 1, 0));
+        }
+    }
+
+    /// The whole point of scoring every candidate: a cliff is not slope
+    /// limited, and the grammar still has to answer for it. A clean two-level
+    /// fault must come back as ONE exact steep ramp, not a shelf.
+    #[test]
+    fn a_cliff_resolves_to_one_exact_steep_ramp() {
+        let fit = fit_cell([0, 40, 40, 0]);
+        assert_eq!(fit.kind, SurfaceKind::Ramp(Turn(2)));
+        assert_eq!((fit.base, fit.rise, fit.error), (0, 40, 0));
+    }
+
+    /// Fit FROM BELOW. Every candidate takes the minimum of the corners it
+    /// covers, so no fitted surface may sit above a sampled vertex -- that is
+    /// what stops one cell protruding through its neighbour.
+    #[test]
+    fn no_fitted_surface_ever_rises_above_a_sampled_corner() {
+        // An exhaustive sweep over small four-corner fields, including every
+        // pattern outside the sloped grammar.
+        for a in 0..4 {
+            for b in 0..4 {
+                for c in 0..4 {
+                    for d in 0..4 {
+                        let corners = [a, b, c, d];
+                        let fit = fit_cell(corners);
+                        assert!(
+                            fit.error >= 0,
+                            "corners {corners:?} fitted above the sample: error {}",
+                            fit.error
+                        );
+                        assert!(fit.base <= *corners.iter().min().unwrap());
+                        assert!(fit.rise >= 0 && fit.cap_rise >= 0);
+                        assert!(
+                            fit.base + fit.rise + fit.cap_rise <= *corners.iter().max().unwrap(),
+                            "corners {corners:?} fitted a peak above the highest sample"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Anything the grammar can express exactly, it must express exactly --
+    /// otherwise a smooth field would render with residual steps even where the
+    /// vocabulary covers it.
+    #[test]
+    fn every_representable_cell_is_fitted_with_no_residual() {
+        let mut representable = 0;
+        for a in 0..3 {
+            for b in 0..3 {
+                for c in 0..3 {
+                    for d in 0..3 {
+                        let corners = [a, b, c, d];
+                        let range = corners.iter().max().unwrap() - corners.iter().min().unwrap();
+                        // Two-level cells and the diagonal 0-1-2-1 stack are the
+                        // whole vocabulary; a cell needs to be one of them.
+                        let levels: std::collections::BTreeSet<_> = corners.iter().collect();
+                        let diagonal_stack = range == 2
+                            && levels.len() == 3
+                            && (0..4).any(|k| {
+                                corners[k] == 2
+                                    && corners[(k + 2) & 3] == 0
+                                    && corners[(k + 1) & 3] == 1
+                                    && corners[(k + 3) & 3] == 1
+                            });
+                        if levels.len() > 2 && !diagonal_stack {
+                            continue;
+                        }
+                        representable += 1;
+                        assert_eq!(
+                            fit_cell(corners).error,
+                            0,
+                            "corners {corners:?} are inside the grammar and must fit exactly"
+                        );
+                    }
+                }
+            }
+        }
+        assert!(
+            representable > 40,
+            "the sweep must actually cover the grammar"
+        );
+    }
+
+    #[test]
+    fn a_flat_cell_never_pays_for_a_wedge_when_a_brick_would_do() {
+        // Same residual as several zero-information wedge fits; the tie-break
+        // must take the single brick.
+        assert_eq!(fit_cell([5, 5, 5, 5]).kind.brick_count(), 1);
+        assert_eq!(fit_cell([5, 5, 5, 5]).kind, SurfaceKind::Flat);
+    }
+}

--- a/src/opt/terrain.rs
+++ b/src/opt/terrain.rs
@@ -324,6 +324,12 @@ pub fn gen_terrain_heightmap<F: Fn(f32) -> bool>(
     if width == 0 || height == 0 {
         return Err("Heightmap is empty".to_string());
     }
+    // A zero cell size would make `layout.half` zero, which divides by zero in
+    // `merge_foundations` (`MAX_HALF_EXTENT / layout.half`) and would emit
+    // zero-extent bricks besides. Refuse it like the other invalid inputs above.
+    if options.size == 0 {
+        return Err("Brick size must be at least 1".to_string());
+    }
 
     // Increased to an even number, with a minimum of 2. A rise of `rise_unit`
     // units becomes a `BrickSize` half height of `rise_unit / 2`. That value
@@ -1077,6 +1083,17 @@ mod tests {
             }
             let (low, high) = (spans[0].0, spans.last().unwrap().1);
             assert!(high > low, "the cell ({x}, {y}) has an empty foundation");
+        }
+    }
+
+    /// A zero brick size must be refused with an error, not a divide-by-zero
+    /// panic in `merge_foundations` (`MAX_HALF_EXTENT / layout.half`).
+    #[test]
+    fn a_zero_brick_size_is_refused_not_a_panic() {
+        let opts = GenOptions { size: 0, ..options() };
+        match gen_terrain_heightmap(&Flat(4, 4, 2), &Grey(4, 4), opts, |_| true) {
+            Err(e) => assert!(e.contains("size"), "unexpected error: {e}"),
+            Ok(_) => panic!("a zero brick size must be refused"),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,25 +2,27 @@ use brdb::{BString, Brick, Collision, World};
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-/// How the heightmap's SURFACE is built, as opposed to which brick asset the
-/// blocky modes stack.
+/// How the code makes the SURFACE of the heightmap. This is different from the
+/// brick asset that the other modes use.
 ///
-/// [`SurfaceMode::Blocks`] is every renderer that existed before sloped output
-/// did: one prism per (optimized) region, top face flat, asset chosen by
-/// `GenOptions::asset`. The other two replace that emission step entirely and
-/// pick their own assets, so `asset`/`micro`/`stud`/`snap`/`quadtree`/`greedy`
-/// mean nothing to them -- the CLI and the GUI both say so rather than letting
-/// a flag look honoured.
+/// [`SurfaceMode::Blocks`] is each renderer that came before the sloped modes.
+/// It makes one box for each area, the top face is flat, and
+/// `GenOptions::asset` gives the asset. The other two modes replace that step
+/// and select their own assets. To them `asset`, `micro`, `stud`, `snap`,
+/// `quadtree` and `greedy` have no meaning. The CLI and the GUI both tell the
+/// user this, because an option that appears to work but does nothing is
+/// worse.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum SurfaceMode {
-    /// Stacked prisms (quadtree or greedy). The historical behaviour.
+    /// Boxes above boxes, with the quadtree method or the greedy method. This
+    /// is the earlier behavior.
     #[default]
     Blocks,
-    /// Smooth micro-wedge terrain: one shared-vertex grid, one calibrated
-    /// shape per cell. See `opt::terrain`.
+    /// Smooth micro wedge terrain: one grid of shared vertices, and one
+    /// calibrated shape for each cell. Refer to `opt::terrain`.
     Terrain,
-    /// Wrapperup's rampifier over the height column field: full-size ramps,
-    /// wedges and ramp corners fitted onto the surface. See `opt::rampify`.
+    /// The Wrapperup rampifier over the height columns: usual ramps, wedges
+    /// and corner ramps on the surface. Refer to `opt::rampify`.
     Rampify,
 }
 
@@ -39,9 +41,9 @@ pub struct GenOptions {
     pub nocollide: bool,
     pub quadtree: bool,
     pub greedy: bool,
-    /// Which surface renderer runs. Defaults to [`SurfaceMode::Blocks`], the
-    /// pre-existing behaviour, so an untouched `GenOptions` renders exactly as
-    /// it always did.
+    /// The surface renderer that runs. The default is
+    /// [`SurfaceMode::Blocks`], which is the earlier behavior. A `GenOptions`
+    /// that you do not change thus gives the same result as before.
     pub surface: SurfaceMode,
 }
 
@@ -56,9 +58,9 @@ impl GenOptions {
         }
     }
 
-    /// The collision flags every renderer in this crate builds from
-    /// `--nocollide`, in one place so the sloped modes cannot drift from the
-    /// blocky ones.
+    /// The collision values that each renderer makes from `--nocollide`. They
+    /// are in one function, so the sloped modes always agree with the other
+    /// modes.
     pub fn collision(&self) -> Collision {
         Collision {
             player: !self.nocollide,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,28 @@
-use brdb::{BString, Brick, World};
+use brdb::{BString, Brick, Collision, World};
 use std::ffi::OsStr;
 use std::path::PathBuf;
+
+/// How the heightmap's SURFACE is built, as opposed to which brick asset the
+/// blocky modes stack.
+///
+/// [`SurfaceMode::Blocks`] is every renderer that existed before sloped output
+/// did: one prism per (optimized) region, top face flat, asset chosen by
+/// `GenOptions::asset`. The other two replace that emission step entirely and
+/// pick their own assets, so `asset`/`micro`/`stud`/`snap`/`quadtree`/`greedy`
+/// mean nothing to them -- the CLI and the GUI both say so rather than letting
+/// a flag look honoured.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum SurfaceMode {
+    /// Stacked prisms (quadtree or greedy). The historical behaviour.
+    #[default]
+    Blocks,
+    /// Smooth micro-wedge terrain: one shared-vertex grid, one calibrated
+    /// shape per cell. See `opt::terrain`.
+    Terrain,
+    /// Wrapperup's rampifier over the height column field: full-size ramps,
+    /// wedges and ramp corners fitted onto the surface. See `opt::rampify`.
+    Rampify,
+}
 
 pub struct GenOptions {
     pub size: u16,
@@ -17,6 +39,10 @@ pub struct GenOptions {
     pub nocollide: bool,
     pub quadtree: bool,
     pub greedy: bool,
+    /// Which surface renderer runs. Defaults to [`SurfaceMode::Blocks`], the
+    /// pre-existing behaviour, so an untouched `GenOptions` renders exactly as
+    /// it always did.
+    pub surface: SurfaceMode,
 }
 
 impl GenOptions {
@@ -27,6 +53,19 @@ impl GenOptions {
             1
         } else {
             2
+        }
+    }
+
+    /// The collision flags every renderer in this crate builds from
+    /// `--nocollide`, in one place so the sloped modes cannot drift from the
+    /// blocky ones.
+    pub fn collision(&self) -> Collision {
+        Collision {
+            player: !self.nocollide,
+            weapon: !self.nocollide,
+            interact: !self.nocollide,
+            tool: !self.nocollide,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
thx apx for reminding me do this
integrate wrap's rampifier and my own smooth terrain experiments

smooth terrain:
<img width="2342" height="1273" alt="image" src="https://github.com/user-attachments/assets/75341ef1-f6a2-4914-a9ea-261135690103" />

<img width="2475" height="1316" alt="image" src="https://github.com/user-attachments/assets/78444eeb-ce0c-464e-a340-78c343fd3082" />


rampify:
<img width="1841" height="1233" alt="image" src="https://github.com/user-attachments/assets/6d5b4d12-977f-4875-a122-8617d0cc3325" />


UI changes:
added into existing "Brick Type"
<img width="1493" height="98" alt="image" src="https://github.com/user-attachments/assets/9286ccf2-b9aa-4786-a0f9-819853367d05" />
