### PR TITLE
feat(heightmap): improve user experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,8 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ image = { version = "0.25.10", default-features = false, features = [
   "png",
   "gif",
   "webp",
+  # The CLI and the GUI accept .jpg heightmaps and colormaps. Without this
+  # feature the decode of such a file fails.
+  "jpeg",
 ] }
 log = "0.4.28"
 # Standard MIDI File parser (midi::parse). Pure Rust, no_std-capable, wasm-safe,

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Common:
       --glow              Emit at 0 glow intensity
       --nocollide         Disable brick collision
       --hdmap             RGB-encoded high-detail heightmap
-      --lrgb              Treat input colour as linear rather than sRGB
+      --lrgb              deprecated, ignored (colours are never converted now)
 
 Heightmap surface:
       --tile/--smooth/--micro/--stud   flat-topped brick style

--- a/src/gui/heightmap.rs
+++ b/src/gui/heightmap.rs
@@ -117,7 +117,6 @@ pub struct HeightmapApp {
     optimization: OptimizationMode,
     opt_cull: bool,
     opt_nocollide: bool,
-    opt_lrgb: bool,
     opt_hdmap: bool,
     opt_snap: bool,
     opt_glow: bool,
@@ -140,7 +139,6 @@ impl Default for HeightmapApp {
             optimization: OptimizationMode::Quad,
             opt_cull: false,
             opt_nocollide: false,
-            opt_lrgb: false,
             opt_snap: false,
             opt_glow: false,
             opt_hdmap: false,
@@ -160,6 +158,38 @@ impl HeightmapApp {
             |img: &PickedImage| -> bool { img.image.width() > 1024 || img.image.height() > 1024 };
 
         self.heightmaps.iter().any(check_image) || self.colormap.as_ref().map_or(false, check_image)
+    }
+
+    /// The pixel size of the source image, or `None` if no image is picked.
+    ///
+    /// The build uses the size of the HEIGHTMAP. It uses the size of the
+    /// colormap only if there is no heightmap. `maps_from_images` makes the
+    /// same selection, thus the readout agrees with the render.
+    fn source_size(&self, img_only: bool) -> Option<(u32, u32)> {
+        let img = if img_only {
+            self.colormap.as_ref()
+        } else {
+            self.heightmaps.first().or(self.colormap.as_ref())
+        };
+        img.map(|i| (i.image.width(), i.image.height()))
+    }
+
+    /// The size that the current selection builds at the current settings.
+    ///
+    /// The value comes from `options()` and not from the sliders. A mode can
+    /// change what a slider COUNTS. Micro mode counts micro units, not studs.
+    fn footprint(&self, img_only: bool) -> Option<Footprint> {
+        let options = self.options(img_only);
+        self.source_size(img_only).map(|px| {
+            footprint(
+                px,
+                options.size,
+                // An image render is one layer of bricks. A shade of grey
+                // thus adds no height.
+                if options.img { 0 } else { options.scale },
+                255,
+            )
+        })
     }
 
     /// Poll an in-flight file pick and apply the result.
@@ -199,12 +229,14 @@ impl HeightmapApp {
             self.mode.surface()
         };
         GenOptions {
-            // `--size` counts STUDS in each mode, but the micro mode counts
-            // micro units.
+            // `--size` counts STUDS in each mode, but micro mode counts
+            // micro units. Use a saturating multiply: the slider does not
+            // clamp a typed value, and the CLI has no limit. A typed value
+            // multiplied by five overflows first.
             size: if self.mode == BrickMode::Micro {
                 self.horizontal_size
             } else {
-                self.horizontal_size * 5
+                self.horizontal_size.saturating_mul(5)
             },
             scale: self.vertical_scale,
             cull: self.opt_cull,
@@ -226,7 +258,6 @@ impl HeightmapApp {
             img,
             glow: self.opt_glow,
             hdmap: self.opt_hdmap,
-            lrgb: self.opt_lrgb,
             nocollide: self.opt_nocollide,
             quadtree: self.optimization == OptimizationMode::Quad,
             greedy: self.optimization == OptimizationMode::Greedy,
@@ -246,6 +277,18 @@ impl HeightmapApp {
             self.heightmaps.clone()
         };
         let colormap = self.colormap.clone();
+        // The picture for the in-game preview: the colormap, or the
+        // heightmap if there is no colormap. The render makes the same
+        // selection. Get the image here, where both selections are available.
+        // The worker receives only the boxed `Colormap` trait.
+        let preview_source = colormap
+            .as_ref()
+            .or(heightmaps.first())
+            .map(|p| p.image.clone());
+        let save_name = std::path::Path::new(&out_file)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
 
         let progress_tx = self.progress_channel.0.clone();
         // Send failures are IGNORED, as in the Video and Audio panes: a closed
@@ -286,9 +329,35 @@ impl HeightmapApp {
                 })?;
                 stopped()?;
 
+                // Do the check BEFORE the write. The game cannot load a save
+                // above the chunk limit, and a failure in the game wastes the
+                // full render. Only the completed bricks give the count. Refer
+                // to `check_chunk_limit`.
+                let chunks = check_chunk_limit(&bricks)?;
+                info!(
+                    "Save spans {} of the {} chunks the game will load",
+                    commas(chunks as u64),
+                    commas(MAX_SAVE_CHUNKS as u64)
+                );
+
                 info!("Writing Save to {}", out_file);
                 progress("Writing", 0.95);
-                let data = bricks_to_save(bricks);
+                let mut data = bricks_to_save(bricks);
+
+                // The in-game preview. A generated save has no screenshot of
+                // itself, thus the source map gives a view from above. A save
+                // with no preview shows an empty tile in the browser. An
+                // encode failure only writes a log message, because it must
+                // not stop the render.
+                if let Some(source) = &preview_source {
+                    match save_screenshot(source) {
+                        Ok(screenshot) => data.meta.screenshot = Some(screenshot),
+                        Err(e) => error!("no save preview embedded: {e}"),
+                    }
+                }
+                if !save_name.is_empty() {
+                    data.meta.bundle.name = save_name.clone();
+                }
 
                 // This pane's own extension branch, now shared with the other
                 // four -- see `gui::util::deliver_world`. It was the only one
@@ -346,14 +415,75 @@ impl HeightmapApp {
             save_destination_row(t, ui, shared);
             out_file_warning_row(t, ui, &shared.out_file);
 
+            // The slider tracks stop at the limit of the GAME, not at a
+            // round number. `MAX_BRICK_HALF_EXTENT` is the largest half
+            // extent of a procedural brick, and one pixel is one brick. Micro
+            // mode counts micro units, thus the same physical limit is five
+            // times the value. Both tracks stopped at 100 before, which gave
+            // micro mode one fifth of the range of the CLI. A typed value can
+            // be more than the track (`SliderClamping::Never`), because the
+            // CLI has no limit.
+            let (unit, max_horizontal) = if self.mode == BrickMode::Micro {
+                ("micro units", MAX_BRICK_HALF_EXTENT)
+            } else {
+                ("studs", MAX_BRICK_HALF_EXTENT / 5)
+            };
             t.row_hover(ui, "Horizontal Scale", Some("The size of each pixel in studs (or microbricks)"), |ui| {
-                widgets::slider(ui, egui::Slider::new(&mut self.horizontal_size, 1..=100).text("studs"));
+                widgets::slider(
+                    ui,
+                    egui::Slider::new(&mut self.horizontal_size, 1..=max_horizontal)
+                        .clamping(egui::SliderClamping::Never)
+                        .text(unit),
+                )
+                .on_hover_text(format!(
+                    "The track stops at {max_horizontal} {unit}. One pixel then fills the \
+                     largest brick the game allows ({} units across). Type a larger value to \
+                     go above the track, as --size does",
+                    MAX_BRICK_HALF_EXTENT * 2
+                ));
             });
             if !img_only {
                 t.row_hover(ui, "Vertical Size", Some("The height of each shade of grey from the heightmap"), |ui| {
-                    widgets::slider(ui, egui::Slider::new(&mut self.vertical_scale, 1..=100).text("units"));
+                    // No brick limit applies here. The code divides a high
+                    // column into pieces of 250 units or less. Thus
+                    // `--vertical` accepts any value, and this track does not
+                    // stop at 100.
+                    widgets::slider(
+                        ui,
+                        egui::Slider::new(&mut self.vertical_scale, 1..=1000)
+                            .clamping(egui::SliderClamping::Never)
+                            .logarithmic(true)
+                            .text("units"),
+                    )
+                    .on_hover_text(
+                        "The height of one shade of grey, in units. Type a larger value to go \
+                         above the track, as --vertical does",
+                    );
                 });
             }
+
+            t.row_hover(ui, "Estimated Size", Some("The size of the finished build, from the image size and the scales above. Real-world values use one brick unit per inch, thus ten inches per stud"), |ui| {
+                ui.vertical(|ui| match self.footprint(img_only) {
+                    None => {
+                        ui.label("Select an image to see the size of the build");
+                    }
+                    Some(plan) => {
+                        ui.label(plan.size_text());
+                        ui.label(plan.real_text());
+                        // A flat image render has no shade of grey to give
+                        // height, so there is no height to report.
+                        if plan.max_height_units > 0 {
+                            ui.label(plan.height_text());
+                        }
+                        if plan.over_brick_limit() {
+                            ui.colored_label(
+                                Color32::from_rgb(255, 200, 100),
+                                format!("Note: {}", plan.brick_limit_text()),
+                            );
+                        }
+                    }
+                });
+            });
 
             t.row_hover(ui, "Optimization", Some("Algorithm used to reduce brick count"), |ui| {
                 // Vertical for the same reason as the Brick Type row below: the
@@ -393,8 +523,6 @@ impl HeightmapApp {
                     );
                     widgets::toggle(ui, &mut self.opt_nocollide, "No Collide")
                         .on_hover_text("Disable brick collision");
-                    widgets::toggle(ui, &mut self.opt_lrgb, "LRGB")
-                        .on_hover_text("Use linear rgb input color instead of sRGB");
                     widgets::toggle(ui, &mut self.opt_glow, "Glow")
                         .on_hover_text("Glow bricks at lowest intensity");
                     if !img_only {
@@ -703,6 +831,93 @@ mod tests {
             Err("failed to write file".to_string()),
             "a converted error must still be reported to the user"
         );
+    }
+
+    fn picked(w: u32, h: u32) -> PickedImage {
+        PickedImage {
+            name: "test.png".to_string(),
+            image: std::sync::Arc::new(image::RgbaImage::new(w, h)),
+        }
+    }
+
+    /// The readout must follow what the slider COUNTS in the selected mode.
+    ///
+    /// Micro mode counts micro units, and each other mode counts studs. The
+    /// same slider value thus builds one fifth of the map. A readout that
+    /// used the slider value would show five times the correct size.
+    #[test]
+    fn the_size_readout_follows_the_brick_mode_the_slider_is_counted_in() {
+        let mut app = HeightmapApp::default();
+        app.heightmaps = vec![picked(1024, 1024)];
+        app.horizontal_size = 1;
+
+        app.mode = BrickMode::Default;
+        let studs = app.footprint(false).expect("an image is selected");
+        assert_eq!(studs.studs, (1024.0, 1024.0));
+
+        app.mode = BrickMode::Micro;
+        let micro = app.footprint(false).expect("an image is selected");
+        assert_eq!(micro.studs, (204.8, 204.8));
+    }
+
+    /// The build uses the size of the HEIGHTMAP if there is one, because
+    /// `maps_from_images` builds from that image. A colormap of a different
+    /// size does not change the build, thus it must not change the readout.
+    #[test]
+    fn the_readout_measures_the_image_the_render_is_built_from() {
+        let mut app = HeightmapApp::default();
+        app.heightmaps = vec![picked(512, 256)];
+        app.colormap = Some(picked(64, 64));
+        assert_eq!(app.footprint(false).unwrap().pixels, (512, 256));
+
+        // The Image2Brick page renders the colormap and ignores heightmaps.
+        assert_eq!(app.footprint(true).unwrap().pixels, (64, 64));
+
+        // With no image there is no size, and the code must not panic.
+        assert!(HeightmapApp::default().footprint(false).is_none());
+    }
+
+    /// The size readout must REACH the pane. This row exists only to be read.
+    /// A row that stops painting looks the same as a pane with no data.
+    #[test]
+    fn the_pane_paints_the_size_readout_for_a_selected_image() {
+        let ctx = Context::default();
+        crate::gui::theme::install(&ctx);
+        let mut app = HeightmapApp::default();
+        app.heightmaps = vec![picked(1024, 1024)];
+        let mut shared = SharedOptions::default();
+
+        let mut texts: Vec<String> = Vec::new();
+        for _ in 0..4 {
+            let input = egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::pos2(0.0, 0.0),
+                    egui::vec2(900.0, 2400.0),
+                )),
+                ..Default::default()
+            };
+            let out = ctx.run(input, |ctx| {
+                egui::CentralPanel::default().show(ctx, |ui| {
+                    app.draw_settings(ui, &mut shared, false);
+                });
+            });
+            texts = out
+                .shapes
+                .iter()
+                .filter_map(|c| match &c.shape {
+                    egui::epaint::Shape::Text(t) => Some(t.galley.text().to_string()),
+                    _ => None,
+                })
+                .collect();
+        }
+
+        let plan = app.footprint(false).unwrap();
+        for want in [plan.size_text(), plan.real_text(), plan.height_text()] {
+            assert!(
+                texts.iter().any(|t| *t == want),
+                "the pane never painted {want:?}; it painted {texts:?}"
+            );
+        }
     }
 
     /// The Brick Type and Optimization notes must sit BELOW their buttons, at

--- a/src/gui/util.rs
+++ b/src/gui/util.rs
@@ -457,7 +457,7 @@ pub fn maps_from_images(
     let colormap_img = colormap
         .or(heightmaps.first())
         .ok_or_else(|| "no images selected".to_string())?;
-    let colormap = ColormapPNG::from_image((*colormap_img.image).clone(), options.lrgb);
+    let colormap = ColormapPNG::from_image((*colormap_img.image).clone());
 
     let heightmap: Box<dyn Heightmap> = if options.img {
         Box::new(HeightmapFlat::new(colormap.size()).unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn cli() -> clap::App<'static, 'static> {
         (@arg wedge: --wedge "Build TERRACED wedge terrain: tops stay flat, every height is a whole terrace step, and the outlines of the terraces are cut at 45 degrees by vertical side wedges (PB_DefaultSideWedge) -- convex corners chamfered, concave corners filled, collinear staircases merged into single large wedges, flat tops greedy-merged into boxes. Unbuildable configurations (diagonal crossings, spikes) are eroded first. Unlike --terrain and --rampify, slopes are not approximated: this is the terraced 'brick terrain' look of hand-built Brickadia maps. Replaces --tile/--smooth/--micro/--stud and the optimizers")
         (@arg prefab: --prefab "Heightmap/image renders: write a PREFAB bundle instead of a world, so the save can be dropped in Brickadia's Prefabs folder and spawned from the prefab browser rather than loaded as a level")
         (@arg snap: --snap "Snap bricks to the brick grid")
-        (@arg lrgb: --lrgb "Use linear rgb input color instead of sRGB")
+        (@arg lrgb: --lrgb "DEPRECATED and ignored. Colormap pixels always go into the bricks without conversion, because a save file stores brick colours in the same encoding as an image")
         (@arg img: -i --img "Make the heightmap flat and render an image")
         (@arg glow: --glow "Make the heightmap (or animation display) glow at 0 intensity")
         (@arg srgb2lin: --("srgb-to-linear") "Animation: convert sRGB frame colors to linear before encoding (use if the render looks too bright)")
@@ -290,8 +290,19 @@ fn main() {
     if matches.is_present("srgb2lin") && !matches.is_present("animmode") {
         warn!(
             "--srgb-to-linear applies to --anim-mode renders only (it converts a FRAME's \
-             colours before they are encoded). The heightmap and --img paths have --lrgb for \
-             the same job; --text has no colour encoding to convert"
+             colours before they are encoded). The heightmap and --img paths convert nothing \
+             at all; --text has no colour encoding to convert"
+        );
+    }
+
+    // `--lrgb` disabled a default sRGB to linear conversion of the colormap.
+    // That conversion is removed. A save file stores brick colours in the same
+    // encoding as an image, thus the conversion only made each render darker
+    // than its colormap. The flag stays as a no-op for existing scripts.
+    if matches.is_present("lrgb") {
+        warn!(
+            "--lrgb is deprecated and has no effect. Colormap pixels always go into the \
+             bricks without conversion, which is what --lrgb selected"
         );
     }
 
@@ -1493,9 +1504,24 @@ fn run_heightmap(
     }
     let blocks = surface == SurfaceMode::Blocks;
 
+    // `--size` counts STUDS, which are 5 units of half extent each. With
+    // `--micro` it counts micro units. Use `checked_mul`: the half extent is a
+    // u16, thus `--size 20000` overflowed and rendered a map at an incorrect
+    // size.
+    let micro_size = matches.is_present("micro") && blocks;
+    let units_per_stud = if micro_size { 1 } else { 5 };
+    let Some(half_extent) = size.checked_mul(units_per_stud) else {
+        fail!(
+            "--size {size} is too large. One pixel would be more than {} units across, which \
+             is more than one brick can be. The maximum brick size is {} units",
+            u16::MAX,
+            MAX_BRICK_HALF_EXTENT * 2
+        );
+    };
+
     // output options
     let options = GenOptions {
-        size: size * if matches.is_present("micro") && blocks { 1 } else { 5 },
+        size: half_extent,
         scale,
         cull: matches.is_present("cull"),
         asset: if matches.is_present("micro") {
@@ -1509,13 +1535,12 @@ fn run_heightmap(
         } else {
             PB_DEFAULT_BRICK
         },
-        micro: matches.is_present("micro") && blocks,
+        micro: micro_size,
         stud: matches.is_present("stud") && blocks,
         snap: matches.is_present("snap"),
         img: matches.is_present("img") && blocks,
         glow: matches.is_present("glow"),
         hdmap: matches.is_present("hdmap"),
-        lrgb: matches.is_present("lrgb"),
         nocollide: matches.is_present("nocollide"),
         quadtree: true,
         greedy: matches.is_present("greedy"),
@@ -1529,14 +1554,12 @@ fn run_heightmap(
         .map(|s| s.to_lowercase())
         .as_deref()
     {
-        Some("png") | Some("jpg") | Some("jpeg") => {
-            match ColormapPNG::new(&colormap_file, options.lrgb) {
-                Ok(map) => map,
-                Err(err) => {
-                    fail!("Error reading colormap: {:?}", err);
-                }
+        Some("png") | Some("jpg") | Some("jpeg") => match ColormapPNG::new(&colormap_file) {
+            Ok(map) => map,
+            Err(err) => {
+                fail!("Error reading colormap: {:?}", err);
             }
-        }
+        },
         Some(ext) => {
             fail!("Unsupported colormap format '{}'", ext);
         }
@@ -1566,6 +1589,28 @@ fn run_heightmap(
         fail!("Unsupported heightmap format");
     };
 
+    // The size of the render, before it runs. The GUI shows the same values
+    // below its scale sliders.
+    let plan = footprint(
+        heightmap.size(),
+        options.size,
+        if options.img { 0 } else { options.scale },
+        255,
+    );
+    info!("Build size: {}", plan.size_text());
+    info!(
+        "  {} x {} units, {} at 1 unit = 1 inch",
+        commas(plan.units.0),
+        commas(plan.units.1),
+        plan.real_text()
+    );
+    if !options.img {
+        info!("  {}", plan.height_text());
+    }
+    if plan.over_brick_limit() {
+        warn!("--size {size}: {}", plan.brick_limit_text());
+    }
+
     // Not `.expect(...)`: `gen_opt_heightmap` returns a `String` describing a
     // real user-facing condition (an image it cannot use), and a panic trace
     // reads as a crash rather than as the refusal it is.
@@ -1574,8 +1619,42 @@ fn run_heightmap(
         Err(e) => fail!("{e}"),
     };
 
+    // Do the check BEFORE the write. The game cannot load a save above the
+    // chunk limit, and a failure in the game wastes the full render.
+    match check_chunk_limit(&bricks) {
+        Ok(chunks) => info!(
+            "Save spans {} of the {} chunks the game will load",
+            commas(chunks as u64),
+            commas(MAX_SAVE_CHUNKS as u64)
+        ),
+        Err(e) => fail!("{e}"),
+    }
+
     info!("Writing Save to {}", out_file);
     let mut data = bricks_to_save(bricks);
+
+    // Each save gets a preview, world or prefab. The game shows a grid of
+    // pictures, and a generated save has no screenshot of itself. The source
+    // map gives a view from above. Use the COLORMAP, which shows the colours
+    // of the build. Without `-c`, `colormap_file` is already the heightmap.
+    //
+    // An encode failure only writes a warning, because it must not stop the
+    // render.
+    match save_screenshot(colormap.image()) {
+        Ok(screenshot) => {
+            data.meta.screenshot = Some(screenshot);
+            info!("Save preview: {}", colormap_file.display());
+        }
+        Err(e) => warn!("no save preview embedded: {e}"),
+    }
+    // The game names its own bundles, and the browser tile shows this name.
+    // Use the output file name: `-o "Big Island.brz"` gives "Big Island".
+    if data.meta.bundle.name.is_empty() {
+        if let Some(stem) = std::path::Path::new(&out_file).file_stem() {
+            data.meta.bundle.name = stem.to_string_lossy().to_string();
+        }
+    }
+
     // A prefab bundle and a world bundle differ in their metadata only. The
     // difference is `level_type` and the block of pivots and bounds that
     // `make_prefab` calculates from the brick positions. The code thus changes

--- a/src/map.rs
+++ b/src/map.rs
@@ -4,8 +4,6 @@ use std::{
     result::Result,
 };
 
-use crate::util::to_linear_rgb;
-
 // generic heightmap trait returns scalar from X and Y
 pub trait Heightmap {
     fn at(&self, x: u32, y: u32) -> u32;
@@ -105,17 +103,18 @@ impl HeightmapFlat {
 // PNG based colormap
 pub struct ColormapPNG {
     source: RgbaImage,
-    lrgb: bool,
 }
 
-// Read in a color from X, Y
+/// Read a color from X, Y.
+///
+/// The code uses the pixel EXACTLY as the image holds it. A save file stores
+/// brick colours in the same encoding as an image, thus no conversion is
+/// necessary. An sRGB to linear conversion ran here by default before, and
+/// `--lrgb` disabled it. That conversion only made each render darker than
+/// its colormap.
 impl Colormap for ColormapPNG {
     fn at(&self, x: u32, y: u32) -> [u8; 4] {
-        if self.lrgb {
-            self.source.get_pixel(x, y).0
-        } else {
-            to_linear_rgb(self.source.get_pixel(x, y).0)
-        }
+        self.source.get_pixel(x, y).0
     }
 
     fn size(&self) -> (u32, u32) {
@@ -125,16 +124,59 @@ impl Colormap for ColormapPNG {
 
 // Colormap image input
 impl ColormapPNG {
-    pub fn new(file: impl AsRef<Path>, lrgb: bool) -> Result<Self, String> {
+    pub fn new(file: impl AsRef<Path>) -> Result<Self, String> {
         if let Ok(img) = image::open(&file) {
-            Ok(Self::from_image(img.to_rgba8(), lrgb))
+            Ok(Self::from_image(img.to_rgba8()))
         } else {
             Err(format!("Could not open image {}", file.as_ref().display()))
         }
     }
 
     /// Construct from an already-decoded image (web builds have no filesystem).
-    pub fn from_image(source: RgbaImage, lrgb: bool) -> Self {
-        ColormapPNG { source, lrgb }
+    pub fn from_image(source: RgbaImage) -> Self {
+        ColormapPNG { source }
+    }
+
+    /// The decoded image of the colormap.
+    ///
+    /// The save embeds this image as its preview (`util::save_screenshot`).
+    /// The accessor prevents a second decode of the same file.
+    pub fn image(&self) -> &RgbaImage {
+        &self.source
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **A brick has the colour of its colormap pixel.**
+    ///
+    /// This path applied an sRGB to linear transfer to each pixel by default,
+    /// and `--lrgb` disabled it. The transfer made each render darker than its
+    /// image. A save file stores brick colours in the same encoding as an
+    /// image, thus no conversion is necessary. The transfer stays for the
+    /// animation encoders. The last assertion shows that the colormap does not
+    /// use it.
+    #[test]
+    fn colormap_pixels_reach_the_bricks_exactly_as_the_image_holds_them() {
+        let mut img = RgbaImage::new(3, 1);
+        img.put_pixel(0, 0, image::Rgba([12, 128, 250, 255]));
+        img.put_pixel(1, 0, image::Rgba([255, 255, 255, 255]));
+        // `--cull` reads the alpha channel, thus alpha must also stay.
+        img.put_pixel(2, 0, image::Rgba([0, 0, 0, 128]));
+        let map = ColormapPNG::from_image(img);
+
+        assert_eq!(map.at(0, 0), [12, 128, 250, 255]);
+        assert_eq!(map.at(1, 0), [255, 255, 255, 255]);
+        assert_eq!(map.at(2, 0), [0, 0, 0, 128]);
+        assert_eq!(map.size(), (3, 1));
+
+        let converted = crate::util::to_linear_rgb([12, 128, 250, 255]);
+        assert_ne!(
+            map.at(0, 0),
+            converted,
+            "the colormap must not use the linear transfer, which gives {converted:?}"
+        );
     }
 }

--- a/src/opt/rampify.rs
+++ b/src/opt/rampify.rs
@@ -1081,7 +1081,6 @@ mod tests {
             img: false,
             glow: false,
             hdmap: false,
-            lrgb: false,
             nocollide: false,
             quadtree: true,
             greedy: false,

--- a/src/opt/terrain.rs
+++ b/src/opt/terrain.rs
@@ -975,7 +975,6 @@ mod tests {
             img: false,
             glow: false,
             hdmap: false,
-            lrgb: false,
             nocollide: false,
             quadtree: true,
             greedy: false,

--- a/src/opt/wedge.rs
+++ b/src/opt/wedge.rs
@@ -1032,7 +1032,6 @@ mod tests {
             img: false,
             glow: false,
             hdmap: false,
-            lrgb: false,
             nocollide: false,
             quadtree: false,
             greedy: false,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
-use brdb::{BString, Brick, Collision, World};
+use brdb::{BString, Brick, CHUNK_SIZE, ChunkIndex, Collision, World};
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
@@ -41,7 +42,6 @@ pub struct GenOptions {
     pub img: bool,
     pub glow: bool,
     pub hdmap: bool,
-    pub lrgb: bool,
     pub nocollide: bool,
     pub quadtree: bool,
     pub greedy: bool,
@@ -76,6 +76,246 @@ impl GenOptions {
     }
 }
 
+/// The units per stud on the brick grid. A 1x1 brick is 10 units on a side.
+pub const UNITS_PER_STUD: f64 = 10.0;
+
+/// The real-world inches per brick unit. One unit is one inch, thus one stud
+/// is ten inches. The area readout uses this rule.
+pub const INCHES_PER_UNIT: f64 = 1.0;
+
+const INCHES_PER_MILE: f64 = 63360.0;
+const INCHES_PER_FOOT: f64 = 12.0;
+
+/// The largest half extent of a procedural brick, in units.
+///
+/// One pixel becomes one brick or more, and [`GenOptions::size`] is the half
+/// extent of that brick. This value thus bounds the horizontal scale. The
+/// quadtree optimizer stops merging at the same value.
+pub const MAX_BRICK_HALF_EXTENT: u16 = 500;
+
+/// The number of chunks the game loads from one save.
+///
+/// A chunk is a cube of [`CHUNK_SIZE`] units. A save with more chunks than
+/// this does not complete its load. [`check_chunk_limit`] refuses to write
+/// such a save.
+pub const MAX_SAVE_CHUNKS: usize = 100_000;
+
+/// The size of a render, in bricks and in real-world units.
+///
+/// All values come from the pixel count of the image and from
+/// [`GenOptions::size`]. Thus the code can show the size before the render.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Footprint {
+    /// The size of the source image, in pixels.
+    pub pixels: (u32, u32),
+    /// The half extent of one pixel's brick, in units ([`GenOptions::size`]).
+    pub half_extent: u16,
+    /// The horizontal size of the build, in units.
+    pub units: (u64, u64),
+    /// The same size in studs. The value is fractional in micro mode, where
+    /// one pixel can be one fifth of a stud.
+    pub studs: (f64, f64),
+    /// The real-world area, at one inch per unit.
+    pub sq_miles: f64,
+    /// The height of the build at the brightest shade of the heightmap.
+    pub max_height_units: u64,
+}
+
+const SQ_FEET_PER_SQ_MILE: f64 = 27_878_400.0;
+
+/// Write `n` with a comma between each group of three digits.
+///
+/// The size readout shows values of six digits or more. Grouped digits are
+/// easier to read.
+pub fn commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.char_indices() {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Write a stud count. Show one decimal only below 10 studs.
+///
+/// Micro mode can put one fifth of a stud in a pixel. Larger counts do not
+/// need tenths.
+fn studs_text(v: f64) -> String {
+    if v >= 10.0 {
+        commas(v.round() as u64)
+    } else {
+        format!("{v:.1}")
+    }
+}
+
+/// Write a real-world length. Use miles, or feet below one tenth of a mile.
+fn length_text(units: u64) -> String {
+    let inches = units as f64 * INCHES_PER_UNIT;
+    let miles = inches / INCHES_PER_MILE;
+    if miles >= 0.1 {
+        format!("{miles:.2} mi")
+    } else {
+        format!("{} ft", commas((inches / INCHES_PER_FOOT).round() as u64))
+    }
+}
+
+impl Footprint {
+    /// `1,024 x 1,024 px -> 5,120 x 5,120 studs`
+    ///
+    /// The line shows studs only. The unit count is ten times the stud count.
+    /// The log shows it instead.
+    pub fn size_text(&self) -> String {
+        format!(
+            "{} x {} px  ->  {} x {} studs",
+            commas(self.pixels.0 as u64),
+            commas(self.pixels.1 as u64),
+            studs_text(self.studs.0),
+            studs_text(self.studs.1),
+        )
+    }
+
+    /// `0.81 mi x 0.81 mi, 0.66 sq mi`
+    ///
+    /// The values use one inch per unit. The row tooltip gives that rule. The
+    /// line does not repeat it.
+    pub fn real_text(&self) -> String {
+        format!(
+            "{} x {}, {}",
+            length_text(self.units.0),
+            length_text(self.units.1),
+            self.area_text(),
+        )
+    }
+
+    /// Write the real-world area. Use square miles, or square feet below one
+    /// tenth of a square mile.
+    ///
+    /// Most heightmaps cover less than one mile. "0.03 sq mi" gives less
+    /// information than the equivalent 728,000 sq ft.
+    pub fn area_text(&self) -> String {
+        if self.sq_miles >= 0.1 {
+            format!("{:.2} sq mi", self.sq_miles)
+        } else {
+            format!(
+                "{} sq ft",
+                commas((self.sq_miles * SQ_FEET_PER_SQ_MILE).round() as u64)
+            )
+        }
+    }
+
+    /// `up to 2,550 studs tall (2,125 ft)`
+    ///
+    /// The line uses the same two units as the horizontal lines.
+    pub fn height_text(&self) -> String {
+        format!(
+            "up to {} studs tall ({})",
+            studs_text(self.max_height_units as f64 / UNITS_PER_STUD),
+            length_text(self.max_height_units),
+        )
+    }
+
+    /// The real-world width and length in miles, at one inch per unit.
+    pub fn miles(&self) -> (f64, f64) {
+        (
+            self.units.0 as f64 * INCHES_PER_UNIT / INCHES_PER_MILE,
+            self.units.1 as f64 * INCHES_PER_UNIT / INCHES_PER_MILE,
+        )
+    }
+
+    /// The height of the highest point in feet, at one inch per unit.
+    pub fn max_height_feet(&self) -> f64 {
+        self.max_height_units as f64 * INCHES_PER_UNIT / INCHES_PER_FOOT
+    }
+
+    /// Show if one pixel is larger than one brick can be.
+    ///
+    /// The CLI and the GUI do not clamp the horizontal scale to the limit.
+    /// Both report this condition instead.
+    pub fn over_brick_limit(&self) -> bool {
+        self.half_extent > MAX_BRICK_HALF_EXTENT
+    }
+
+    /// `each pixel is 1,200 units across, more than the 1,000 ...`
+    pub fn brick_limit_text(&self) -> String {
+        format!(
+            "each pixel is {} units across, more than the {} of one brick. The game can \
+             refuse bricks of this size",
+            commas(self.half_extent as u64 * 2),
+            commas(MAX_BRICK_HALF_EXTENT as u64 * 2),
+        )
+    }
+}
+
+/// Calculate the size that an image of `pixels` builds at this scale.
+///
+/// `size` is [`GenOptions::size`], the half extent of one pixel in units. One
+/// pixel thus covers `2 * size` units in each brick mode. `scale` is
+/// [`GenOptions::scale`], the height in units of one shade of grey.
+/// `max_level` is the brightest shade of the heightmap, 255 for an 8-bit map.
+pub fn footprint(pixels: (u32, u32), size: u16, scale: u32, max_level: u32) -> Footprint {
+    let units = (
+        pixels.0 as u64 * 2 * size as u64,
+        pixels.1 as u64 * 2 * size as u64,
+    );
+    let max_height_units = scale as u64 * max_level as u64;
+
+    Footprint {
+        pixels,
+        half_extent: size,
+        units,
+        studs: (
+            units.0 as f64 / UNITS_PER_STUD,
+            units.1 as f64 / UNITS_PER_STUD,
+        ),
+        sq_miles: (units.0 as f64 * INCHES_PER_UNIT / INCHES_PER_MILE)
+            * (units.1 as f64 * INCHES_PER_UNIT / INCHES_PER_MILE),
+        max_height_units,
+    }
+}
+
+/// Count the save chunks that a set of bricks occupies.
+///
+/// The count uses `Position::to_relative`, the same function that `brdb` uses
+/// to put a brick into a chunk. The two counts thus agree.
+pub fn count_chunks(bricks: &[Brick]) -> usize {
+    bricks
+        .iter()
+        .map(|b| b.position.to_relative().0)
+        .collect::<HashSet<ChunkIndex>>()
+        .len()
+}
+
+/// Refuse a save that the game cannot load. Return the chunk count.
+///
+/// The function returns the count because the caller must not read all the
+/// bricks a second time.
+///
+/// **Only the completed bricks give this count.** The optimizer decides how
+/// many bricks a render makes and where their centers are. A map can cover
+/// 100 chunks with 12 merged bricks. Thus the code does not estimate the
+/// count before the render. It does the check at save time.
+///
+/// The count increases with the AREA of the build, not with its detail. Thus
+/// the message tells the user to decrease the horizontal scale or to use a
+/// smaller image.
+pub fn check_chunk_limit(bricks: &[Brick]) -> Result<usize, String> {
+    let chunks = count_chunks(bricks);
+    if chunks > MAX_SAVE_CHUNKS {
+        return Err(format!(
+            "this save has {} chunks, more than the {} that the game loads from one save. It \
+             would not complete its load. Each chunk is a cube of {CHUNK_SIZE} units. Decrease \
+             the horizontal scale (--size / Horizontal Scale) or the vertical scale \
+             (--vertical / Vertical Size), or use a smaller heightmap",
+            commas(chunks as u64),
+            commas(MAX_SAVE_CHUNKS as u64),
+        ));
+    }
+    Ok(chunks)
+}
+
 // convert gamma to linear gamma
 pub fn to_linear_gamma(c: u8) -> u8 {
     let cf = (c as f64) / 255.0;
@@ -86,7 +326,13 @@ pub fn to_linear_gamma(c: u8) -> u8 {
     }) as u8
 }
 
-// convert sRGB to linear rgb
+/// [`to_linear_gamma`] over an RGBA pixel, alpha untouched.
+///
+/// The colormap path does NOT use this: brick colours in a save file are
+/// stored in the same encoding an image is, so converting only darkened every
+/// render away from the colormap it was given. It stays for the animation
+/// encoders' `--srgb-to-linear`, which converts frame pixels for a different
+/// reason (a hex-encoded gate reads its colour as linear).
 pub fn to_linear_rgb(rgb: [u8; 4]) -> [u8; 4] {
     [
         to_linear_gamma(rgb[0]),
@@ -207,11 +453,74 @@ pub fn to_linear_rgb_f32(rgba: [u8; 4]) -> [f32; 4] {
     ]
 }
 
-// given an array of bricks, create a save
+/// The longest edge of the `Meta/Screenshot.jpg` of a save.
+///
+/// The game writes screenshots of 1280x720 pixels. That size is its render
+/// resolution, not a limit. This constant bounds the long edge only and keeps
+/// the shape of the map.
+const SCREENSHOT_EDGE: u32 = 1280;
+
+/// The JPEG quality of the preview. The game shows the preview at a few
+/// hundred pixels. A higher quality gives no visible improvement.
+const SCREENSHOT_QUALITY: u8 = 85;
+
+/// Encode the `Meta/Screenshot.jpg` of a generated save.
+///
+/// The game shows a grid of previews. A generated save has no render of
+/// itself, but the source map is a view of the build from above. Use the
+/// colormap, because it shows the colors of the build. Use the heightmap when
+/// there is no colormap. The render makes the same selection.
+///
+/// The caller writes this preview for each heightmap save, world or prefab.
+/// The preview was applied only with `--prefab` before. Thus a GUI save, which
+/// is always a world bundle, had no preview.
+///
+/// The function keeps the shape of the map. It does not pad the map into the
+/// 16:9 shape of a game screenshot, because a heightmap is usually square.
+pub fn save_screenshot(source: &image::RgbaImage) -> Result<Vec<u8>, String> {
+    use image::{DynamicImage, codecs::jpeg::JpegEncoder, imageops};
+
+    let (w, h) = (source.width().max(1), source.height().max(1));
+    let scale = (SCREENSHOT_EDGE as f32 / w as f32).min(SCREENSHOT_EDGE as f32 / h as f32);
+    let fitted = if scale >= 1.0 {
+        // Use Nearest to enlarge. A heightmap is pixel art, and a smooth
+        // filter removes the pixel grid.
+        DynamicImage::ImageRgba8(source.clone()).resize_exact(
+            (w as f32 * scale).round().max(1.0) as u32,
+            (h as f32 * scale).round().max(1.0) as u32,
+            imageops::FilterType::Nearest,
+        )
+    } else {
+        DynamicImage::ImageRgba8(source.clone()).resize(
+            SCREENSHOT_EDGE,
+            SCREENSHOT_EDGE,
+            imageops::FilterType::Lanczos3,
+        )
+    };
+
+    // JPEG has no alpha channel. An RGBA image causes an encode error, thus
+    // remove the alpha channel here.
+    let rgb = fitted.to_rgb8();
+    let mut out = std::io::Cursor::new(Vec::new());
+    JpegEncoder::new_with_quality(&mut out, SCREENSHOT_QUALITY)
+        .encode_image(&rgb)
+        .map_err(|e| format!("failed to encode the save preview: {e}"))?;
+    Ok(out.into_inner())
+}
+
+/// Create a save from an array of bricks.
+///
+/// The description holds the brick count. The game shows the description next
+/// to the preview. The count tells the user if the build is loadable, and only
+/// the render knows it.
 pub fn bricks_to_save(bricks: Vec<Brick>) -> World {
     let mut world = World::new();
+    let count = bricks.len();
     world.add_bricks(bricks);
-    world.meta.bundle.description = "Save generated from heightmap file".to_string();
+    world.meta.bundle.description = format!(
+        "Save generated from heightmap file\n{} bricks",
+        commas(count as u64)
+    );
     world
 }
 
@@ -241,6 +550,208 @@ pub fn write_world(world: &World, out_file: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use brdb::{BrickSize, BrickType, Position, assets::bricks::PB_DEFAULT_BRICK};
+
+    /// A 1024x1024 map at the default scale, in each unit of the readout.
+    ///
+    /// One pixel is `2 * size` units wide, because `size` is a HALF extent.
+    /// The full readout depends on this rule. At `--size 1`, one stud,
+    /// `GenOptions::size` is 5. One pixel is thus 10 units, or one stud.
+    #[test]
+    fn a_stud_per_pixel_builds_one_stud_per_pixel() {
+        let plan = footprint((1024, 1024), 5, 1, 255);
+        assert_eq!(plan.units, (10_240, 10_240));
+        assert_eq!(plan.studs, (1024.0, 1024.0));
+        // 10,240 inches is 853.3 ft. The area is that value squared.
+        let (mi_x, _) = plan.miles();
+        assert!((mi_x - 0.16162).abs() < 1e-4, "{mi_x} miles across");
+        assert!((plan.sq_miles - 0.026121).abs() < 1e-5, "{} sq mi", plan.sq_miles);
+    }
+
+    /// Micro mode counts MICRO units, not studs. The same slider value thus
+    /// builds one fifth of the map. For this reason the readout uses
+    /// `GenOptions::size` and not the slider.
+    #[test]
+    fn micro_units_build_a_fifth_of_what_the_same_number_of_studs_does() {
+        let micro = footprint((1024, 1024), 1, 1, 255);
+        let studs = footprint((1024, 1024), 5, 1, 255);
+        assert_eq!(micro.units, (2048, 2048));
+        assert_eq!(micro.studs, (204.8, 204.8));
+        assert_eq!(studs.units.0, micro.units.0 * 5);
+    }
+
+    /// The height is the vertical scale multiplied by the brightest shade.
+    /// The readout gives it in feet, at one inch per unit.
+    #[test]
+    fn the_tallest_column_is_the_vertical_scale_times_the_brightest_shade() {
+        let plan = footprint((16, 16), 5, 100, 255);
+        assert_eq!(plan.max_height_units, 25_500);
+        assert!((plan.max_height_feet() - 2125.0).abs() < 1e-6);
+    }
+
+    fn brick_at(x: i32, y: i32, z: i32) -> Brick {
+        Brick {
+            asset: BrickType::Procedural {
+                asset: PB_DEFAULT_BRICK,
+                size: BrickSize::new(5, 5, 6),
+            },
+            position: Position::new(x, y, z),
+            ..Default::default()
+        }
+    }
+
+    /// The count uses the same rule as the writer. A brick belongs to the
+    /// CHUNK_SIZE cube that contains its position. The brick count is not
+    /// related.
+    #[test]
+    fn bricks_sharing_a_chunk_are_counted_once() {
+        let same = vec![
+            brick_at(0, 0, 0),
+            brick_at(10, 20, 30),
+            brick_at(CHUNK_SIZE - 1, 0, 0),
+        ];
+        assert_eq!(count_chunks(&same), 1);
+
+        let spread = vec![
+            brick_at(0, 0, 0),
+            brick_at(CHUNK_SIZE, 0, 0),
+            brick_at(0, CHUNK_SIZE, 0),
+            brick_at(0, 0, CHUNK_SIZE),
+            // Negative coordinates give different chunks. The grid is
+            // signed and has its center at the origin.
+            brick_at(-1, 0, 0),
+        ];
+        assert_eq!(count_chunks(&spread), 5);
+    }
+
+    /// The function must refuse above the limit and accept at the limit.
+    #[test]
+    fn a_save_over_the_chunk_limit_is_refused_before_it_is_written() {
+        // Use a 400x250 grid of chunks, not one row. `ChunkIndex` holds
+        // each axis in an i16. 100,000 chunks on one axis thus overflow and
+        // collide.
+        let at_limit: Vec<Brick> = (0..MAX_SAVE_CHUNKS)
+            .map(|i| brick_at((i % 400) as i32 * CHUNK_SIZE, (i / 400) as i32 * CHUNK_SIZE, 0))
+            .collect();
+        assert_eq!(count_chunks(&at_limit), MAX_SAVE_CHUNKS);
+        assert_eq!(check_chunk_limit(&at_limit), Ok(MAX_SAVE_CHUNKS));
+
+        let mut over = at_limit;
+        over.push(brick_at(0, 0, CHUNK_SIZE));
+        let err = check_chunk_limit(&over).expect_err("one chunk above the limit is refused");
+        assert!(
+            err.contains("100001") || err.contains("100,001"),
+            "the message must give the count: {err}"
+        );
+        assert!(
+            err.contains("--size"),
+            "the message must name the option that corrects it: {err}"
+        );
+    }
+
+    /// The CLI and the GUI permit a pixel that is wider than one brick. The
+    /// code must report this condition.
+    #[test]
+    fn a_pixel_too_wide_to_be_one_brick_is_reported() {
+        let ok = footprint((16, 16), MAX_BRICK_HALF_EXTENT, 1, 255);
+        assert!(!ok.over_brick_limit());
+
+        let over = footprint((16, 16), MAX_BRICK_HALF_EXTENT + 1, 1, 255);
+        assert!(over.over_brick_limit());
+        // Give the full width, which the user sees in the game. Do not give
+        // the half extent, which is how the option is stored.
+        assert!(
+            over.brick_limit_text().contains("1,002 units"),
+            "{}",
+            over.brick_limit_text()
+        );
+    }
+
+    /// The readout has three short lines. The log gives the unit count. The
+    /// tooltip gives the one inch per unit rule. Repetition of these on each
+    /// line hides the values.
+    #[test]
+    fn the_readout_lines_carry_studs_and_real_world_size_and_nothing_else() {
+        let plan = footprint((1024, 1024), 5, 150, 255);
+
+        assert_eq!(plan.size_text(), "1,024 x 1,024 px  ->  1,024 x 1,024 studs");
+        assert_eq!(plan.real_text(), "0.16 mi x 0.16 mi, 728,178 sq ft");
+        // Studs and a real-world length, as in the two lines above. Not the
+        // 38,250 units of the stored height. This build is more than half a
+        // mile high, thus the line changes to miles at the same limit as the
+        // horizontal lines.
+        assert_eq!(plan.height_text(), "up to 3,825 studs tall (0.60 mi)");
+        // A lower build stays in feet.
+        assert_eq!(
+            footprint((16, 16), 5, 10, 255).height_text(),
+            "up to 255 studs tall (213 ft)"
+        );
+
+        for line in [plan.size_text(), plan.real_text(), plan.height_text()] {
+            assert!(!line.contains("units"), "{line}");
+            assert!(!line.contains("inch"), "{line}");
+        }
+    }
+
+    /// `Meta/Screenshot.jpg` must be a JPEG and must keep the shape of the
+    /// map.
+    #[test]
+    fn a_save_preview_is_a_jpeg_that_keeps_the_maps_shape() {
+        // The source is two times as wide as it is high. A change to 16:9,
+        // or to a square, thus changes the size in the result.
+        let source = image::RgbaImage::from_pixel(2048, 1024, image::Rgba([10, 20, 30, 255]));
+        let jpg = save_screenshot(&source).expect("encodes");
+        assert_eq!(&jpg[..2], &[0xFF, 0xD8], "Screenshot.jpg must be a JPEG");
+
+        let shot = image::load_from_memory(&jpg).expect("the game must decode it");
+        assert_eq!((shot.width(), shot.height()), (1280, 640), "2:1 stays 2:1");
+
+        // A map that is smaller than the box is enlarged to fill it.
+        let small = image::RgbaImage::from_pixel(64, 64, image::Rgba([9, 9, 9, 255]));
+        let shot = image::load_from_memory(&save_screenshot(&small).expect("encodes")).unwrap();
+        assert_eq!((shot.width(), shot.height()), (1280, 1280));
+    }
+
+    /// The game shows the bundle description next to the preview. The
+    /// description must give the brick count with grouped digits, because the
+    /// count can be more than one million.
+    #[test]
+    fn the_save_description_states_the_brick_count() {
+        let world = bricks_to_save(vec![brick_at(0, 0, 0); 1_234_567]);
+        assert!(
+            world.meta.bundle.description.contains("1,234,567 bricks"),
+            "{}",
+            world.meta.bundle.description
+        );
+        assert_eq!(bricks_to_save(vec![]).meta.bundle.description.lines().count(), 2);
+    }
+
+    #[test]
+    fn big_numbers_are_grouped_so_they_can_be_read() {
+        assert_eq!(commas(0), "0");
+        assert_eq!(commas(999), "999");
+        assert_eq!(commas(1_000), "1,000");
+        assert_eq!(commas(51_200), "51,200");
+        assert_eq!(commas(1_234_567), "1,234,567");
+    }
+
+    /// Most heightmaps cover less than one mile. An area readout in square
+    /// miles only would show "0.00 sq mi" for almost every render.
+    #[test]
+    fn a_small_build_reports_feet_rather_than_a_rounded_off_zero() {
+        let small = footprint((64, 64), 5, 1, 255);
+        assert!(small.sq_miles < 0.1);
+        assert!(
+            small.area_text().ends_with("sq ft"),
+            "{}",
+            small.area_text()
+        );
+        assert!(small.real_text().contains(" ft"), "{}", small.real_text());
+
+        let big = footprint((8192, 8192), 5, 1, 255);
+        assert_eq!(big.area_text(), "1.67 sq mi");
+        assert!(big.real_text().contains("1.29 mi"), "{}", big.real_text());
+    }
 
     /// The 0.04045 knee, in 8-bit terms: `0.04045 * 255 = 10.31`, so 10 is the
     /// last sample on the linear segment and 11 the first on the power

--- a/tests/prefab_preview.rs
+++ b/tests/prefab_preview.rs
@@ -1,0 +1,89 @@
+//! Each generated save carries the source map as its in-game preview.
+//!
+//! The game shows a grid of pictures, and a generated save has no render of
+//! itself. The colormap, or the heightmap without `-c`, gives a view of the
+//! build from above.
+//!
+//! **This applies to all saves, not only prefabs.** The preview was applied
+//! only with `--prefab` before. Each GUI save is a world bundle and thus had
+//! no preview. These tests use both bundle types.
+//!
+//! The tests read a `.brz` file and not the `WorldMeta` fields, because the
+//! path in the archive controls what the game finds.
+
+use brdb::IntoReader;
+use heightmap::util::save_screenshot;
+
+fn source_image() -> image::RgbaImage {
+    image::RgbaImage::from_pixel(800, 400, image::Rgba([40, 90, 140, 255]))
+}
+
+fn save_with_preview(name: &str, prefab: bool) -> brdb::World {
+    let mut world = brdb::World::new();
+    world.add_bricks(vec![brdb::Brick {
+        asset: brdb::BrickType::Procedural {
+            asset: brdb::assets::bricks::PB_DEFAULT_BRICK,
+            size: brdb::BrickSize::new(5, 5, 6),
+        },
+        position: brdb::Position::new(0, 0, 6),
+        ..Default::default()
+    }]);
+    world.meta.screenshot = Some(save_screenshot(&source_image()).expect("encode the preview"));
+    world.meta.bundle.name = name.to_string();
+    if prefab {
+        world.make_prefab();
+    }
+    world
+}
+
+fn written(world: &brdb::World, tag: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!("h2b_preview_{tag}_{}.brz", std::process::id()));
+    std::fs::write(&path, world.to_brz_vec().expect("encode")).expect("write");
+    path
+}
+
+#[test]
+fn a_prefab_bundle_carries_the_source_map_as_its_preview() {
+    let path = written(&save_with_preview("Test Prefab", true), "prefab");
+    let db = brdb::Brz::open(&path).expect("reopen").into_reader();
+
+    assert!(
+        db.prefab_json().expect("read").is_some(),
+        "the bundle must be a prefab, or this test repeats the world case"
+    );
+    assert_eq!(
+        db.bundle_json().expect("read").name,
+        "Test Prefab",
+        "the browser tile shows only the bundle name"
+    );
+
+    let screenshot = db
+        .screenshot()
+        .expect("read")
+        .expect("Meta/Screenshot.jpg must be in the archive, because it is the preview");
+    assert_eq!(&screenshot[..2], &[0xFF, 0xD8], "Screenshot.jpg must be a JPEG");
+    let shot = image::load_from_memory(&screenshot).expect("the game must decode it");
+    assert_eq!((shot.width(), shot.height()), (1280, 640), "the 2:1 shape of the map");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The world bundle. The GUI writes this type only, and the CLI writes it
+/// without `--prefab`.
+#[test]
+fn a_world_bundle_carries_one_too() {
+    let path = written(&save_with_preview("Test World", false), "world");
+    let db = brdb::Brz::open(&path).expect("reopen").into_reader();
+
+    assert!(
+        db.prefab_json().expect("read").is_none(),
+        "this test uses the WORLD bundle"
+    );
+    assert!(
+        db.screenshot().expect("read").is_some(),
+        "a world save must also carry a preview, because the GUI writes this type"
+    );
+    assert_eq!(db.bundle_json().expect("read").name, "Test World");
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
- Get rid of SRGB option, no longer need to do color conversion and makes no sense to keep it
- Show size of what you are converting
<img width="469" height="151" alt="image" src="https://github.com/user-attachments/assets/00e976d8-0765-4ff5-a533-e8ae45cb002e" />

- Expand limits for height
- Show brickcount in save description
- Attach the heightmap as screenshot, or colormap if used
<img width="855" height="676" alt="image" src="https://github.com/user-attachments/assets/049c3453-9024-4b65-893e-c012a33ed82c" />


- Error when the save has too many chunks for Brickadia to be able to load